### PR TITLE
feat/#8 API 모듈화

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,9 @@ const nextConfig = {
 
     return config;
   },
+  env: {
+    BASE_URL: process.env.BASE_URL,
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "axios": "^0.27.2",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/src/service/base.ts
+++ b/src/service/base.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const baseURL = `${process.env.BASE_URL}`;
+
+const unauth = axios.create({ baseURL });
+
+export { unauth };

--- a/src/service/comment.ts
+++ b/src/service/comment.ts
@@ -1,0 +1,31 @@
+import { unauth } from './base';
+import { ICommentItem } from '~/types/comment';
+
+export const getCommentList = (questionId: number) => {
+  return unauth.get<{ comments: ICommentItem[] }>(`/questions/${questionId}/comments`);
+};
+
+export const createComment = (
+  questionId: number,
+  payload: { nickname: string; password: string; content: string },
+) => {
+  return unauth.post(`/questions/${questionId}/comments`, payload);
+};
+
+export const matchCommentPassword = (questionId: number, commentId: number, password: string) => {
+  return unauth.post(`/questions/${questionId}/comments/${commentId}`, {
+    password,
+  });
+};
+
+export const editComment = (
+  questionId: number,
+  commentId: number,
+  payload: { password: string; content: string },
+) => {
+  return unauth.put(`/questions/${questionId}/comments/${commentId}`, payload);
+};
+
+export const deleteComment = (questionId: number, commentId: number, password: string) => {
+  return unauth.delete(`/questions/${questionId}/comments/${commentId}`, { data: { password } });
+};

--- a/src/service/question.ts
+++ b/src/service/question.ts
@@ -1,0 +1,49 @@
+import { unauth } from './base';
+import { IQuestion, IQuestionItem, ISort } from '~/types/question';
+
+type QuestionListResponse = {
+  content: IQuestionItem[];
+  pageable: {
+    sort: ISort;
+    offset: number;
+    pageNumber: number;
+    pageSize: number;
+    paged: boolean;
+    unpaged: boolean;
+  };
+  sort: ISort;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+  numberOfElements: number;
+  empty: boolean;
+};
+
+type QuestionDetailResponse = IQuestionItem & {
+  additionQuestions: string[];
+};
+
+export const createQuestion = (question: IQuestion) => {
+  return unauth.post<{ id: number }>('/questions', question);
+};
+
+export const deleteQuestion = (questionId: number, password: string) => {
+  return unauth.delete(`/questions/${questionId}`, { data: { password } });
+};
+
+export const getQuestionDetail = (questionId: number) => {
+  return unauth.get<QuestionDetailResponse>(`/questions/${questionId}`);
+};
+
+export const editQuestion = (questionId: number, question: Omit<IQuestion, 'nickname'>) => {
+  return unauth.put(`/questions/${questionId}`, question);
+};
+
+export const matchQuestionPassword = (questionId: number, password: string) => {
+  return unauth.post(`/questions/${questionId}/match`, { password });
+};
+
+export const getQuestionList = () => {
+  return unauth.get<QuestionListResponse>('/questions');
+};

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -7,3 +7,17 @@ export interface IQuestionItem {
   commentCount: number;
   createAt: string;
 }
+
+export interface IQuestion {
+  nickname: string;
+  password: string;
+  title: string;
+  category: string;
+  additionalQuestions: string[];
+}
+
+export interface ISort {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,10 +1588,23 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 axe-core@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -1742,6 +1755,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -1870,6 +1890,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2289,6 +2314,20 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.14.9:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2736,6 +2775,18 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
closes #8 

# 개요
- 질문, 댓글 API 모듈화

# 작업 사항
- axios 라이브러리 설치
- `BASE_URL` 환경 변수 추가
- 인증이 필요 없는 axios instance 추가 
- 질문 API 추가
  - 질문 타입 추가
- 댓글 API 추가

## 예시
```js
useEffect(() => {
  (async () => {
    try {
      const response = await getQuestionList(15, 19, 1234);
      console.log(response.data);
    } catch (error) {
      console.error(error);
    }
  })();
}, []);
```

# 미구현
- `면접 목록 조회` 카테고리 쿼리
- `질문/댓글 비밀번호 확인` 응답값 타입 추가

# 궁금한 점
- [x] 지금은 `getQuestionList`로 호출하는데, `questionAPI.getList`로 호출하는 게 가독성이 더 좋을까요?
- [x] 타입에 대한 피드백 환영합니다😊