### PR TITLE
Feat/#12 useAxios hook 구현

### DIFF
--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,0 +1,49 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { DependencyList, useCallback, useRef, useState } from 'react';
+
+type AxiosFn<Request, Response> = (args: Request) => Promise<AxiosResponse<Response>>;
+
+type UseAxiosReturn<Request, Response> = {
+  isLoading: boolean;
+  error: AxiosError | null;
+  response: AxiosResponse<Response> | null;
+  callback: (args: Request) => Promise<void>;
+};
+
+const useAxios = <Request, Response>(
+  axiosFn: AxiosFn<Request, Response>,
+  dependency: DependencyList,
+): UseAxiosReturn<Request, Response> => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [response, setResponse] = useState<AxiosResponse<Response> | null>(null);
+  const [error, setError] = useState<AxiosError | null>(null);
+
+  const lastCallId = useRef(0);
+
+  const callback = useCallback((...args: any) => {
+    const callId = ++lastCallId.current;
+
+    if (!isLoading) {
+      setIsLoading(true);
+    }
+
+    return axiosFn(args)
+      .then((response) => {
+        if (callId === lastCallId.current) {
+          setResponse(response);
+        }
+      })
+      .catch((error) => {
+        if (callId === lastCallId.current) {
+          setError(error);
+        }
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, dependency);
+
+  return { isLoading, response, error, callback };
+};
+
+export default useAxios;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import MiddleCategory from '~/components/common/MiddleCategory';
 import useAxios from '../hooks/useAxios';
 import { getQuestionList } from '~/service/question';
+import { IQuestionItem } from '~/types/question';
 
 const questions = [
   {
@@ -43,7 +44,8 @@ const frontCategories = [
 ];
 const Home: NextPage = () => {
   const [selectedCategory, setSelectedCategory] = useState('전체');
-  const { isLoading, response, error, callback } = useAxios(
+  const [questions, setQuestions] = useState<IQuestionItem[]>([]);
+  const { isLoading, error, request } = useAxios(
     getQuestionList,
     [selectedCategory],
     (status, message) => {
@@ -55,10 +57,16 @@ const Home: NextPage = () => {
     setSelectedCategory(value);
   };
 
+  const requestQuestionList = async () => {
+    const result = await request(selectedCategory);
+    if (result) {
+      setQuestions(result.data.content);
+    }
+  };
+
   useEffect(() => {
-    callback();
-    console.log(response, error);
-  }, [callback]);
+    requestQuestionList();
+  }, []);
 
   return (
     <div>
@@ -74,7 +82,7 @@ const Home: NextPage = () => {
             onSelect={onSelectCategory}
             currentCategory={selectedCategory}
           />
-          <QuestionList questions={response?.data.content ?? []} />
+          <QuestionList questions={questions} />
           {!isLoading && error && <span>{JSON.stringify(error)}</span>}
           {/* <QuestionList questions={questions} /> */}
         </MainContent>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,8 +3,10 @@ import Head from 'next/head';
 import PageContainer from '~/components/common/PageContainer';
 import QuestionList from '~/components/domain/QuestionList';
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import MiddleCategory from '~/components/common/MiddleCategory';
+import useAxios from '../hooks/useAxios';
+import { getQuestionList } from '~/service/question';
 
 const questions = [
   {
@@ -41,10 +43,23 @@ const frontCategories = [
 ];
 const Home: NextPage = () => {
   const [selectedCategory, setSelectedCategory] = useState('전체');
+  const { isLoading, response, error, callback } = useAxios(
+    getQuestionList,
+    [selectedCategory],
+    (status, message) => {
+      alert(`status: ${status}, message: ${message}`);
+    },
+  );
 
   const onSelectCategory = (value: string) => {
     setSelectedCategory(value);
   };
+
+  useEffect(() => {
+    callback();
+    console.log(response, error);
+  }, [callback]);
+
   return (
     <div>
       <Head>
@@ -59,7 +74,9 @@ const Home: NextPage = () => {
             onSelect={onSelectCategory}
             currentCategory={selectedCategory}
           />
-          <QuestionList questions={questions} />
+          <QuestionList questions={response?.data.content ?? []} />
+          {!isLoading && error && <span>{JSON.stringify(error)}</span>}
+          {/* <QuestionList questions={questions} /> */}
         </MainContent>
       </main>
     </div>


### PR DESCRIPTION
close #12

## ✅ 작업 내용
- useAxios hook 구현
- 메인페이지에서 `면접 목록 조회` API로 사용해본 코드도 같이 올립니다. (merge 전에 삭제)
  - category 값이 이상한 값이어도 정상적으로 응답이 내려와서 에러 테스트는 못 해봤습니다🥺
- `errorHandler` prop 추가

### 테스트 코드 동작

```js
const Home: NextPage = () => {
  ...
  const { isLoading, response, error, callback } = useAxios(
    getQuestionList,
    [selectedCategory],
    (status, message) => {
      alert(`status: ${status}, message: ${message}`);
    },
  );

  useEffect(() => {
    callback();
    console.log(response, error);
  }, [callback]);

  return (
    ...
      <QuestionList questions={response?.data.content ?? []} />
      {!isLoading && error && <span>{JSON.stringify(error)}</span>}
```

https://user-images.githubusercontent.com/96400112/193467974-c7039555-6021-41d0-8f9f-c293ddf4c880.mp4

## 📌 이슈 사항
- ~useAxios, useCallback 훅 로직 한 번 거치고 response, callback을 반환해서 그런지 모두 any 타입으로 변경되는 문제가 있습니다. 제네릭으로 어떻게 하면 타입을 살릴 수 있을 거 같은데..자고 일어나서 다시 도전해보겠습니다.~ -> 하하 아주 지저분하게 해결했습니다
- 위 테스트 코드에서 `useEffect` 의존성 배열에 `error`값을 넣으면 요청 성공 전까지 무한 호출됩니다...

https://user-images.githubusercontent.com/96400112/193468422-57c7beef-0448-4dde-ac2c-eab91984739a.mp4




## ✍ 궁금한 점
- [x] 충분히 테스트를 못 해봐서 빠뜨린 점이 있을 거 같은데 일단 사용하다 수정할지, 테스트를 충분히 하고 사용할지 고민입니다
- [ ] `useAxios`내부에서 요청 성공 시 `error` 객체를 null로 초기화 + 요청 실패 시 `response` 객체를 null로 초기화 코드를 넣었더니, 요청 성공 -> 요청 실패 시 `response` 값이 날아가서 화면 단이 없어지는데 자연스러워 보이나요?