### PR TITLE
Feat/#14 질문 상세 페이지 API 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+# vscode
+.vscode

--- a/src/assets/icons/arrow-down.svg
+++ b/src/assets/icons/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 13.5L18 22.5L27 13.5"  stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/arrow-left.svg
+++ b/src/assets/icons/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22.5 9L13.5 18L22.5 27" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/arrow-right.svg
+++ b/src/assets/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg  viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.5 27L22.5 18L13.5 9" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/arrow-up.svg
+++ b/src/assets/icons/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M27 22.5L18 13.5L9 22.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -1,16 +1,23 @@
 import styled from '@emotion/styled';
 import { ButtonHTMLAttributes, CSSProperties, MouseEvent, ReactNode } from 'react';
-import { buttonStyle } from './types';
+import { buttonSizes, buttonStyle } from './types';
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   buttonType?: keyof typeof buttonStyle;
   disabled?: boolean;
   children?: ReactNode;
   style?: CSSProperties;
+  size?: keyof typeof buttonSizes;
 }
 
-const Button = ({ buttonType, disabled, children, ...props }: ButtonProps) => {
+const Button = ({
+  buttonType = 'black',
+  disabled,
+  children,
+  size = 'md',
+  ...props
+}: ButtonProps) => {
   return (
-    <StyledButton buttonType={buttonType} disabled={disabled} {...props}>
+    <StyledButton buttonType={buttonType} disabled={disabled} size={size} {...props}>
       {children}
     </StyledButton>
   );
@@ -19,14 +26,11 @@ const Button = ({ buttonType, disabled, children, ...props }: ButtonProps) => {
 export default Button;
 
 const StyledButton = styled.button<ButtonProps>`
-  font-size: 14px;
-  padding: 12px 26px;
-  background-color: ${({ theme }) => theme.colors.blackGray};
-  color: white;
   border-radius: 4px;
   white-space: nowrap;
 
   ${({ buttonType }) => buttonType && buttonStyle[buttonType]};
+  ${({ size }) => size && buttonSizes[size]};
 
   &:disabled {
     opacity: 0.7;

--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -2,16 +2,23 @@ import { theme } from '~/types/theme';
 
 export const buttonStyle = {
   black: `
-    font-size: 14px;
-    padding: 12px 26px;
     background-color: ${theme.colors.blackGray};
     color: white;
   `,
   borderGray: `
-    font-size: 14px;
-    padding: 12px 26px;
     border: 1px solid ${theme.colors.lightGray};
     background-color: white;
     color: ${theme.colors.darkGray};
+  `,
+};
+
+export const buttonSizes = {
+  sm: `
+    font-size: 14px;
+    padding: 8px 10px;
+  `,
+  md: `
+    font-size: 14px;
+    padding: 12px 26px;
   `,
 };

--- a/src/components/base/Icon/IconButton.tsx
+++ b/src/components/base/Icon/IconButton.tsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+import Icon, { IconProps } from '.';
+
+interface IconButtonProps extends IconProps {
+  onClick?: () => void;
+}
+
+const IconButton = ({ name, size = '20', color = 'white', onClick }: IconButtonProps) => {
+  return (
+    <StyledButton onClick={onClick}>
+      <Icon name={name} size={size} color={color} />
+    </StyledButton>
+  );
+};
+
+export default IconButton;
+
+const StyledButton = styled.button`
+  svg {
+    display: block;
+  }
+`;

--- a/src/components/base/Icon/index.tsx
+++ b/src/components/base/Icon/index.tsx
@@ -1,15 +1,17 @@
 import { theme, ThemeColors } from '~/types/theme';
+import IconButton from './IconButton';
 import * as icons from './svg';
-
-interface IconProps {
+export interface IconProps {
   name: keyof typeof icons;
   size?: string;
   color?: ThemeColors;
 }
 
-const Icon = ({ name, size = '20', color = 'white' }: IconProps) => {
+const Icon = ({ name, size = '20', color = 'white', ...props }: IconProps) => {
   const SvgIcon = icons[name];
-  return <SvgIcon width={size} height={size} color={theme.colors[color]} />;
+  return <SvgIcon width={size} height={size} color={theme.colors[color]} {...props} />;
 };
+
+Icon.Button = IconButton;
 
 export default Icon;

--- a/src/components/base/Icon/index.tsx
+++ b/src/components/base/Icon/index.tsx
@@ -5,11 +5,20 @@ export interface IconProps {
   name: keyof typeof icons;
   size?: string;
   color?: ThemeColors;
+  stroke?: ThemeColors;
 }
 
-const Icon = ({ name, size = '20', color = 'white', ...props }: IconProps) => {
+const Icon = ({ name, size = '20', color = 'white', stroke = 'white', ...props }: IconProps) => {
   const SvgIcon = icons[name];
-  return <SvgIcon width={size} height={size} color={theme.colors[color]} {...props} />;
+  return (
+    <SvgIcon
+      width={size}
+      height={size}
+      color={theme.colors[color]}
+      stroke={theme.colors[stroke]}
+      {...props}
+    />
+  );
 };
 
 Icon.Button = IconButton;

--- a/src/components/base/Icon/svg.ts
+++ b/src/components/base/Icon/svg.ts
@@ -6,3 +6,7 @@ export { default as Refresh } from '~/assets/icons/refresh.svg';
 export { default as Stop } from '~/assets/icons/stop.svg';
 export { default as Pause } from '~/assets/icons/pause.svg';
 export { default as AlertCircle } from '~/assets/icons/alert-circle.svg';
+export { default as ArrowDown } from '~/assets/icons/arrow-down.svg';
+export { default as ArrowUp } from '~/assets/icons/arrow-up.svg';
+export { default as ArrowLeft } from '~/assets/icons/arrow-left.svg';
+export { default as ArrowRight } from '~/assets/icons/arrow-right.svg';

--- a/src/components/common/Comment/AddCommentForm.tsx
+++ b/src/components/common/Comment/AddCommentForm.tsx
@@ -1,60 +1,84 @@
 import styled from '@emotion/styled';
 import { ChangeEvent, FormEvent, useRef, useState } from 'react';
 import Button from '~/components/base/Button';
+import useForm from '~/hooks/useForm';
+import { SUBMIT_CHECK } from '~/utils/helper/validation';
 
-const AddCommentForm = () => {
-  const [formData, setFormData] = useState({
-    nickname: '',
-    password: '',
-    content: '',
+const initialValues = {
+  nickname: '',
+  password: '',
+  content: '',
+};
+
+export type commentValuesType = {
+  [key in keyof typeof initialValues]: string;
+};
+
+interface AddCommentFormProps {
+  onAddComment: (values: commentValuesType) => void;
+}
+
+const AddCommentForm = ({ onAddComment }: AddCommentFormProps) => {
+  const { values, errors, isLoading, handleChange, handleSubmit, handleReset } = useForm({
+    initialValues,
+    onSubmit,
   });
 
   const nicknameRef = useRef<null | HTMLInputElement>(null);
   const passwordRef = useRef<null | HTMLInputElement>(null);
   const contentRef = useRef<null | HTMLTextAreaElement>(null);
 
-  const onSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    console.log(formData);
-    if (formData.nickname.trim().length < 2) {
-      alert('닉네임은 2자 이상 입력해 주세요.');
+  async function onSubmit() {
+    if (SUBMIT_CHECK.nickname.isValid(values.nickname)) {
+      alert(SUBMIT_CHECK.nickname.message);
       nicknameRef.current?.focus();
       return;
     }
-    if (formData.password.length < 4) {
-      alert('비밀번호는 4자 이상 입력해 주세요.');
+    if (SUBMIT_CHECK.password.isValid(values.password)) {
+      alert(SUBMIT_CHECK.password.message);
       passwordRef.current?.focus();
       return;
     }
-    if (formData.content.trim().length < 1) {
-      alert('댓글의 내용을 작성해 주세요');
+
+    if (SUBMIT_CHECK.comment.isValid(values.content)) {
+      alert((errors.content = SUBMIT_CHECK.comment.message));
       contentRef.current?.focus();
       return;
     }
-  };
 
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
-  };
+    await onAddComment(values);
+    handleReset({ ...values, content: '' });
+  }
 
   return (
-    <Container onSubmit={onSubmit}>
+    <Container>
       <Content>
         <Writer>
-          <Input name="nickname" ref={nicknameRef} placeholder="닉네임" onChange={handleChange} />
-          <Input name="password" ref={passwordRef} placeholder="비밀번호" onChange={handleChange} />
+          <Input
+            name="nickname"
+            ref={nicknameRef}
+            placeholder="닉네임"
+            value={values.nickname}
+            onChange={handleChange}
+          />
+          <Input
+            name="password"
+            type="password"
+            ref={passwordRef}
+            placeholder="비밀번호"
+            value={values.password}
+            onChange={handleChange}
+          />
         </Writer>
         <Textarea
           name="content"
           ref={contentRef}
           placeholder="댓글을 입력해주세요"
+          value={values.content}
           onChange={handleChange}
         />
       </Content>
-      <AddButton type="submit">등록</AddButton>
+      <AddButton onClick={handleSubmit}>등록</AddButton>
     </Container>
   );
 };

--- a/src/components/common/Comment/CommentList.tsx
+++ b/src/components/common/Comment/CommentList.tsx
@@ -1,12 +1,38 @@
 import styled from '@emotion/styled';
+import { ChangeEvent, FormEvent, useState } from 'react';
+import Button from '~/components/base/Button';
+import Icon from '~/components/base/Icon';
+import Input from '~/components/base/Input';
+import PasswordConfirm from '~/components/domain/question/PasswordConfirm';
 import { ICommentItem } from '~/types/comment';
+import { convertDate } from '~/utils/helper/convertor';
 
 interface CommentListProps {
+  id: number;
   comment: ICommentItem;
+  onOpenPassword: (id: number | null) => void;
+  onDeleteComment: (id: number, password: string) => void;
+  openPasswordId: number | null;
 }
 
-const CommentList = ({ comment }: CommentListProps) => {
-  const onDelete = () => {};
+const CommentList = ({
+  id,
+  comment,
+  onOpenPassword,
+  openPasswordId,
+  onDeleteComment,
+}: CommentListProps) => {
+  const handleDelete = () => {
+    onOpenPassword(id);
+  };
+
+  const handlePasswordSubmit = (password: string) => {
+    onDeleteComment(id, password);
+  };
+
+  const handleClose = () => {
+    onOpenPassword(null);
+  };
 
   return (
     <StyledLi>
@@ -17,9 +43,12 @@ const CommentList = ({ comment }: CommentListProps) => {
         <span>{comment.content}</span>
       </Content>
       <Info>
-        <span>{comment.createdAt}</span>
-        <button onClick={onDelete}>삭제</button>
+        <CreatedAt>{convertDate(comment.createdAt)}</CreatedAt>
+        <Icon.Button name="Close" color="mediumGray" size="12" onClick={handleDelete} />
       </Info>
+      {openPasswordId === id && (
+        <PasswordConfirm handlePasswordSubmit={handlePasswordSubmit} handleClose={handleClose} />
+      )}
     </StyledLi>
   );
 };
@@ -30,6 +59,7 @@ const StyledLi = styled.li`
   display: flex;
   padding: 16px 0;
   border-bottom: 1px solid ${({ theme }) => theme.colors.lightGray};
+  position: relative;
 `;
 
 const Writer = styled.div`
@@ -40,6 +70,7 @@ const Writer = styled.div`
   text-overflow: ellipsis;
   color: ${({ theme }) => theme.colors.darkGray};
 `;
+
 const Content = styled.div`
   flex-grow: 1;
   white-space: nowrap;
@@ -53,4 +84,9 @@ const Info = styled.div`
   margin-left: 16px;
   flex-shrink: 0;
   color: ${({ theme }) => theme.colors.mediumGray};
+`;
+
+const CreatedAt = styled.span`
+  font-size: 14px;
+  margin-right: 14px;
 `;

--- a/src/components/common/Comment/index.tsx
+++ b/src/components/common/Comment/index.tsx
@@ -1,22 +1,74 @@
 import styled from '@emotion/styled';
+import { useCallback, useEffect, useState } from 'react';
+import Input from '~/components/base/Input';
+import useAxios from '~/hooks/useAxios';
+import { createComment, deleteComment, getCommentList } from '~/service/comment';
 import { ICommentItem } from '~/types/comment';
-import AddCommentForm from './AddCommentForm';
+import AddCommentForm, { commentValuesType } from './AddCommentForm';
 import CommentList from './CommentList';
 
 interface CommentProps {
-  total: number;
-  comments: ICommentItem[];
+  questionId: number;
 }
 
-const Comment = ({ total, comments }: CommentProps) => {
+const Comment = ({ questionId }: CommentProps) => {
+  const [comments, setComments] = useState<ICommentItem[]>([]);
+  const { isLoading, error, request } = useAxios(getCommentList, []);
+  const [openPasswordId, setOpenPasswordId] = useState<null | number>(null);
+
+  const getComments = async () => {
+    const result = await request(questionId);
+    if (result) {
+      setComments(result.data);
+    }
+  };
+
+  const onOpenPassword = (commentId: number | null) => {
+    setOpenPasswordId(commentId);
+  };
+
+  const onDeleteComment = async (commentId: number, password: string) => {
+    try {
+      await deleteComment(questionId, commentId, password);
+      getComments();
+      setOpenPasswordId(null);
+    } catch {
+      // 상태코드에 따라 다르게 에러 출력하기
+      alert('비밀번호 변경에 실패했습니다.');
+    }
+  };
+
+  const onAddComment = useCallback(async (values: commentValuesType) => {
+    try {
+      await createComment(questionId, values);
+      getComments();
+      setOpenPasswordId(null);
+    } catch {
+      // 상태코드에 따라 다르게 에러 출력하기
+      alert('댓글 등록에 실패했습니다.');
+    }
+  }, []);
+
+  useEffect(() => {
+    getComments();
+  }, []);
+
   return (
     <Container>
-      <TotalCount>댓글 {total}</TotalCount>
+      <TotalCount>댓글 {comments.length}</TotalCount>
+
       <CommentContent>
         {comments.map((comment) => (
-          <CommentList key={comment.id} comment={comment} />
+          <CommentList
+            key={comment.id}
+            id={comment.id}
+            comment={comment}
+            onOpenPassword={onOpenPassword}
+            openPasswordId={openPasswordId}
+            onDeleteComment={onDeleteComment}
+          />
         ))}
-        <AddCommentForm />
+        <AddCommentForm onAddComment={onAddComment} />
       </CommentContent>
     </Container>
   );

--- a/src/components/domain/question/AdditionalQuestions/index.tsx
+++ b/src/components/domain/question/AdditionalQuestions/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import Icon from '~/components/base/Icon';
 
 interface Props {
   questions: string[];
@@ -16,7 +17,13 @@ const AdditionalQuestions = ({ questions }: Props) => {
     <Container>
       <AccordionTitle>
         <h3>예상되는 꼬리 질문 보기</h3>
-        <button onClick={onClickButton}>버튼</button>
+        <button onClick={onClickButton}>
+          {isOpen ? (
+            <Icon name="ArrowUp" size="24" stroke="blackGray" />
+          ) : (
+            <Icon name="ArrowDown" size="24" stroke="blackGray" />
+          )}
+        </button>
       </AccordionTitle>
       {isOpen && (
         <AccordionContent>

--- a/src/components/domain/question/MoveButtons/index.tsx
+++ b/src/components/domain/question/MoveButtons/index.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import { ReactNode } from 'react';
+import Button from '~/components/base/Button';
+
+interface MoveButtonProps {
+  prevId: number;
+  nextId: number;
+}
+
+const MoveButtons = ({ nextId, prevId }: MoveButtonProps) => {
+  const router = useRouter();
+
+  const onMovePrev = () => {
+    if (prevId) {
+      router.push(`/question/${prevId}`);
+    } else {
+      alert('첫 번째 페이지 입니다.');
+    }
+  };
+
+  const onMoveNext = () => {
+    if (nextId) {
+      router.push(`/question/${nextId}`);
+    } else {
+      alert('마지막 페이지 입니다.');
+    }
+  };
+
+  return (
+    <Buttons>
+      <Button buttonType="borderGray" onClick={onMovePrev}>
+        이전 질문
+      </Button>
+      <Button buttonType="borderGray" onClick={onMoveNext}>
+        다음 질문
+      </Button>
+    </Buttons>
+  );
+};
+
+export default MoveButtons;
+
+const Buttons = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 56px;
+`;

--- a/src/components/domain/question/MoveButtons/index.tsx
+++ b/src/components/domain/question/MoveButtons/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import { ReactNode } from 'react';
 import Button from '~/components/base/Button';
+import Icon from '~/components/base/Icon';
 
 interface MoveButtonProps {
   prevId: number;
@@ -29,12 +30,14 @@ const MoveButtons = ({ nextId, prevId }: MoveButtonProps) => {
 
   return (
     <Buttons>
-      <Button buttonType="borderGray" onClick={onMovePrev}>
-        이전 질문
-      </Button>
-      <Button buttonType="borderGray" onClick={onMoveNext}>
-        다음 질문
-      </Button>
+      <PrevButton buttonType="borderGray" onClick={onMovePrev}>
+        <Icon name="ArrowLeft" size="24" stroke="darkGray" />
+        <span>이전 질문</span>
+      </PrevButton>
+      <NextButton buttonType="borderGray" onClick={onMoveNext}>
+        <span> 다음 질문</span>
+        <Icon name="ArrowRight" size="24" stroke="darkGray" />
+      </NextButton>
     </Buttons>
   );
 };
@@ -46,4 +49,16 @@ const Buttons = styled.div`
   display: flex;
   justify-content: space-between;
   margin-top: 56px;
+`;
+
+const PrevButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  padding-left: 16px;
+`;
+
+const NextButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  padding-right: 16px;
 `;

--- a/src/components/domain/question/PasswordConfirm/index.tsx
+++ b/src/components/domain/question/PasswordConfirm/index.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import { ChangeEvent, FormEvent, useState } from 'react';
+import Button from '~/components/base/Button';
+import Icon from '~/components/base/Icon';
+import Input from '~/components/base/Input';
+
+interface PasswordConfirmProps {
+  handlePasswordSubmit: (password: string) => void;
+  handleClose: () => void;
+}
+const PasswordConfirm = ({ handlePasswordSubmit, handleClose }: PasswordConfirmProps) => {
+  const [password, setPassword] = useState('');
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    handlePasswordSubmit(password);
+  };
+  return (
+    <Container>
+      <PasswordForm onSubmit={handleSubmit}>
+        <Input
+          type="password"
+          placeholder="비밀번호 입력"
+          value={password}
+          onChange={handleChange}
+        />
+        <Button size="sm">확인</Button>
+        <button onClick={handleClose}>
+          <Icon name="Close" color="mediumGray" size="12" />
+        </button>
+      </PasswordForm>
+    </Container>
+  );
+};
+
+export default PasswordConfirm;
+
+const Container = styled.div`
+  position: absolute;
+  background-color: white;
+  right: 0;
+  top: -55px;
+  padding: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.lightGray};
+  border-radius: 4px;
+  font-size: 14px;
+  box-shadow: 0px 0px 4px 1px rgb(0 0 0 / 5%);
+`;
+
+const PasswordForm = styled.form`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;

--- a/src/components/domain/question/PasswordConfirm/index.tsx
+++ b/src/components/domain/question/PasswordConfirm/index.tsx
@@ -42,8 +42,8 @@ export default PasswordConfirm;
 const Container = styled.div`
   position: absolute;
   background-color: white;
-  right: 0;
-  top: -55px;
+  right: -9px;
+  top: -5px;
   padding: 8px;
   border: 1px solid ${({ theme }) => theme.colors.lightGray};
   border-radius: 4px;

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,7 +1,7 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import { DependencyList, useCallback, useRef, useState } from 'react';
 
-type AxiosFnVoid<T> = () => Promise<AxiosResponse<T>>;
+type AxiosFnVoid<R> = () => Promise<AxiosResponse<R>>;
 type AxiosFnParams<T, R> = (...args: [T]) => Promise<AxiosResponse<R>>;
 
 type CallbackVoid<R> = () => Promise<AxiosResponse<R> | void>;
@@ -14,7 +14,7 @@ type UseAxiosReturn<T, R> = {
 };
 
 const useAxios = <T, R>(
-  axiosFn: AxiosFnVoid<R> & AxiosFnParams<T, R>,
+  axiosFn: AxiosFnVoid<R> | AxiosFnParams<T, R>,
   dependency: DependencyList,
   errorHandler?: (status: number, message: string) => void,
 ): UseAxiosReturn<T, R> => {

--- a/src/pages/question/[id].tsx
+++ b/src/pages/question/[id].tsx
@@ -11,6 +11,8 @@ import Icon from '~/components/base/Icon';
 import { getQuestionDetail } from '~/service/question';
 import { NextPageContext } from 'next';
 import { IQuestionDetail } from '~/types/question';
+import { useRouter } from 'next/router';
+import MoveButtons from '~/components/domain/question/MoveButtons';
 
 const commentData: ICommentItem[] = [
   {
@@ -80,6 +82,7 @@ const QuestionDetail = ({ detailData }: QuestionDetailProps) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [audioSrc, setAudioSrc] = useState('');
   const audioRef = useRef<null | HTMLAudioElement>(null);
+  const router = useRouter();
 
   let timeoutId = useRef<null | NodeJS.Timeout>(null);
   // 그냥 일반 변수or state 로 저장 시에 timeout을 삭제하려는 시점에 값이 null이기 때문에 초기화가 안됨.
@@ -177,15 +180,6 @@ const QuestionDetail = ({ detailData }: QuestionDetailProps) => {
     onFinish();
   };
 
-  useEffect(() => {
-    console.log(detailData);
-
-    // (async () => {
-    //   const result = await getQuestionDetail(10);
-    //   console.log(result.data);
-    // })();
-  }, []);
-
   return (
     <Container>
       <PostHeader
@@ -240,10 +234,7 @@ const QuestionDetail = ({ detailData }: QuestionDetailProps) => {
           style={{ display: 'none' }}
         ></audio>
         <AdditionalQuestions questions={detailData.additionQuestions} />
-        <MoveButtons>
-          <Button buttonType="borderGray">이전 질문</Button>
-          <Button buttonType="borderGray">다음 질문</Button>
-        </MoveButtons>
+        <MoveButtons prevId={detailData.prevId} nextId={detailData.nextId} />
       </PostContent>
       <Comment total={2} comments={commentData} />
     </Container>
@@ -322,12 +313,6 @@ const TimeArea = styled.div`
   padding-right: 30px;
   flex-grow: 1;
   text-align: center;
-`;
-const MoveButtons = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  margin-top: 56px;
 `;
 
 const MikeButton = styled.button`

--- a/src/pages/question/[id].tsx
+++ b/src/pages/question/[id].tsx
@@ -236,7 +236,7 @@ const QuestionDetail = ({ detailData }: QuestionDetailProps) => {
         <AdditionalQuestions questions={detailData.additionQuestions} />
         <MoveButtons prevId={detailData.prevId} nextId={detailData.nextId} />
       </PostContent>
-      <Comment total={2} comments={commentData} />
+      <Comment questionId={detailData.id} />
     </Container>
   );
 };

--- a/src/pages/question/create.tsx
+++ b/src/pages/question/create.tsx
@@ -13,7 +13,7 @@ import useForm from '~/hooks/useForm';
 import { createQuestion } from '~/service/question';
 import { IQuestion } from '~/types/question';
 import { middleCategories } from '~/utils/constant/category';
-import { checkLength, checkSpace, checkSpecial } from '~/utils/helper/validation';
+import { SUBMIT_CHECK } from '~/utils/helper/validation';
 
 const initialValues = {
   nickname: '',
@@ -29,15 +29,15 @@ type valuesType = {
 const validate = (values: valuesType) => {
   const errors = {} as valuesType;
 
-  if (checkLength(values.nickname, 2, 10) || checkSpecial(values.nickname)) {
-    errors.nickname = '닉네임은 특수문자 제외, 2~10자로 입력해 주세요.';
+  if (SUBMIT_CHECK.nickname.isValid(values.nickname)) {
+    errors.nickname = SUBMIT_CHECK.nickname.message;
   }
-  if (checkLength(values.password, 4, 10) || checkSpace(values.password)) {
-    errors.password = '비밀번호는 공백 제외, 4~10자 이상 입력해 주세요.';
+  if (SUBMIT_CHECK.password.isValid(values.password)) {
+    errors.password = SUBMIT_CHECK.password.message;
   }
 
-  if (checkLength(values.title, 2, 30)) {
-    errors.title = '질문 제목은 2~30자로 입력해 주세요.';
+  if (SUBMIT_CHECK.title.isValid(values.title)) {
+    errors.title = SUBMIT_CHECK.title.message;
   }
 
   if (values.category === 'none') {

--- a/src/service/comment.ts
+++ b/src/service/comment.ts
@@ -2,7 +2,7 @@ import { unauth } from './base';
 import { ICommentItem } from '~/types/comment';
 
 export const getCommentList = (questionId: number) => {
-  return unauth.get<{ comments: ICommentItem[] }>(`/questions/${questionId}/comments`);
+  return unauth.get(`/questions/${questionId}/comments`);
 };
 
 export const createComment = (

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -21,3 +21,13 @@ export interface ISort {
   sorted: boolean;
   unsorted: boolean;
 }
+export interface IQuestionDetail {
+  id: number;
+  title: string;
+  nickname: string;
+  category: string;
+  additionQuestions: string[];
+  viewCount: number;
+  commentCount: number;
+  createdAt: string;
+}

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -30,4 +30,6 @@ export interface IQuestionDetail {
   viewCount: number;
   commentCount: number;
   createdAt: string;
+  prevId: number;
+  nextId: number;
 }

--- a/src/utils/helper/convertor.ts
+++ b/src/utils/helper/convertor.ts
@@ -1,0 +1,5 @@
+// 2022-10-03T07:29:08 -> 22.10.03 07:29:08
+
+export const convertDate = (date: string) => {
+  return date.slice(2, 19).replace(/\T/, ' ').replace(/\-/g, '.');
+};

--- a/src/utils/helper/validation.ts
+++ b/src/utils/helper/validation.ts
@@ -11,3 +11,38 @@ export const checkSpecial = (str: string) => {
   const reg = /[^\w\sㄱ-힣]|[\_]/g;
   return str.match(reg);
 };
+
+export const checkNickname = (nickname: string) => {
+  return checkLength(nickname, 2, 10) || checkSpecial(nickname);
+};
+
+export const checkPassword = (password: string) => {
+  return checkLength(password, 4, 10) || checkSpace(password);
+};
+
+export const checkComment = (comment: string) => {
+  return checkLength(comment, 2, 200);
+};
+
+export const checkTitle = (title: string) => {
+  return checkLength(title, 2, 30);
+};
+
+export const SUBMIT_CHECK = {
+  nickname: {
+    isValid: checkNickname,
+    message: '닉네임은 특수문자 제외, 2~10자로 입력해 주세요.',
+  },
+  password: {
+    isValid: checkPassword,
+    message: '비밀번호는 공백 제외, 4~10자 이상 입력해 주세요.',
+  },
+  comment: {
+    isValid: checkComment,
+    message: '댓글의 내용은 2~200자로 입력해 주세요.',
+  },
+  title: {
+    isValid: checkTitle,
+    message: '질문 제목은 2~30자로 입력해 주세요.',
+  },
+};


### PR DESCRIPTION
close #14 

## ✅ 작업 내용

- 질문 상세 조회, 댓글 조회, 등록, 삭제 API 연결했습니다.
-  선으로만 이루어진 svg의 경우 color로 변경이 되지 않아서 Icon props에 stroke 추가했습니다.
- icon으로 onClick할 경우 button으로 감싸주어야 해서 IconButton 컴포넌트 추가했습니다.
- 
[예시]
```
<Icon.Button name="" size="" color="" onClick={}>
```


## 📌 이슈 사항

- useAxios에 type 에러들이 발생하여 수정은 했는데 또 다른 api함수 넣으니 뭔가 문제가 있는 것 같아서 여러 가지 요청에 대한 경우의 수에서도 처리가 되는지 확인이 필요할 것 같아서 일단은 try catch로 일부 처리해두었습니다. -> 이후 수정할 예정입니다!
- 완성을 위해 마음이 급했는지라 코드가 깔끔하게 작성되지는 않았는데 조금 더 정리가 필요해 보입니다.

## ✍ 궁금한 점
- 변수나 컴포넌트 이름 애매하다고 느끼시는 것 있으시면 코멘트 부탁드립니다.
- 닉네임,비밀번호 등 validation 하는 부분이랑 메세지 겹쳐서 따로 파일에 작성해두기는 했는데 체계적으로 정리된 느낌이 들지는 않네요! 혹시 더 나은 방법이 있다면 코멘트 부탁드립니다~!
- 댓글 삭제할 때 비밀번호 나오는 부분 UI 급한대로 처리를 하긴 했는데 괜찮은가요? ,,ㅎ
