### PR TITLE
Feat/#18 메인페이지 API 연결

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import Button from '~/components/base/Button';
 import Link from '~/components/base/Link';
 import PageContainer from '~/components/common/PageContainer';
 import CategoryListItem from './CategoryListItem';
@@ -13,8 +12,8 @@ const Header = () => {
             <Link href="/">developerwiki</Link>
           </h1>
           <CategoryList>
-            <CategoryListItem href="/" name="프론트엔드" />
-            <CategoryListItem href="/" name="백엔드" />
+            <CategoryListItem href="/?dev=fe" name="프론트엔드" />
+            <CategoryListItem href="/?dev=be" name="백엔드" />
           </CategoryList>
         </LeftArea>
         <Link href="/question/create">질문 등록</Link>
@@ -40,7 +39,7 @@ const LeftArea = styled.div`
   display: flex;
 `;
 
-const CategoryList = styled.div`
+const CategoryList = styled.ul`
   display: flex;
   margin-left: 40px;
 `;

--- a/src/components/common/MiddleCategory/index.tsx
+++ b/src/components/common/MiddleCategory/index.tsx
@@ -35,8 +35,15 @@ const CategoryList = styled.ul`
 
     padding: 12px;
     border-radius: 4px;
+    color: ${({ theme }) => theme.colors.darkGray};
+    cursor: pointer;
+
+    &:hover {
+      color: ${({ theme }) => theme.colors.blackGray};
+    }
 
     &.selected {
+      color: ${({ theme }) => theme.colors.blackGray};
       background-color: ${({ theme }) => theme.colors.bgGray};
     }
   }

--- a/src/components/domain/QuestionList/QuestionItem.tsx
+++ b/src/components/domain/QuestionList/QuestionItem.tsx
@@ -3,14 +3,15 @@ import Icon from '~/components/base/Icon';
 import Link from '~/components/base/Link';
 import { IQuestionItem } from '~/types/question';
 import { formatNumber } from '../../../utils/helper/formatting';
+import { forwardRef, Ref } from 'react';
 
 interface QuestionItemProps {
   question: IQuestionItem;
 }
 
-const QuestionItem = ({ question }: QuestionItemProps) => {
+const QuestionItem = forwardRef(({ question }: QuestionItemProps, ref?: Ref<HTMLLIElement>) => {
   return (
-    <StyledItem>
+    <StyledItem ref={ref}>
       <Link href={`/question/${question.id}`}>
         <CategoryName title={question.category}>
           <span>{question.category}</span>
@@ -31,7 +32,7 @@ const QuestionItem = ({ question }: QuestionItemProps) => {
       </Link>
     </StyledItem>
   );
-};
+});
 
 export default QuestionItem;
 

--- a/src/components/domain/QuestionList/QuestionItem.tsx
+++ b/src/components/domain/QuestionList/QuestionItem.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
+import Icon from '~/components/base/Icon';
 import Link from '~/components/base/Link';
 import { IQuestionItem } from '~/types/question';
+import { formatNumber } from '../../../utils/helper/formatting';
 
 interface QuestionItemProps {
   question: IQuestionItem;
@@ -8,17 +10,23 @@ interface QuestionItemProps {
 
 const QuestionItem = ({ question }: QuestionItemProps) => {
   return (
-    <StyledItem key={question.id}>
+    <StyledItem>
       <Link href={`/question/${question.id}`}>
-        <CategoryName>
+        <CategoryName title={question.category}>
           <span>{question.category}</span>
         </CategoryName>
-        <QuestionTitle>
+        <QuestionTitle title={question.title}>
           <span>{question.title}</span>
         </QuestionTitle>
         <QuestionInfo>
-          <i>댓글</i>
-          <span>{question.commentCount}</span>
+          <QuestionInfoItem title={String(question.commentCount)}>
+            <Icon name="Comment" color="darkGray" size="15" />
+            {formatNumber(question.commentCount)}
+          </QuestionInfoItem>
+          <QuestionInfoItem title={String(question.viewCount)}>
+            <Icon name="Comment" color="darkGray" size="15" />
+            {formatNumber(question.viewCount)}
+          </QuestionInfoItem>
         </QuestionInfo>
       </Link>
     </StyledItem>
@@ -54,4 +62,14 @@ const QuestionInfo = styled.div`
   text-align: right;
   padding: 0 20px;
   flex-shrink: 0;
+`;
+const QuestionInfoItem = styled.span`
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8.5px;
+
+  ~ span {
+    margin-left: 17.5px;
+  }
 `;

--- a/src/components/domain/QuestionList/index.tsx
+++ b/src/components/domain/QuestionList/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { forwardRef, Ref } from 'react';
 import { IQuestionItem } from '~/types/question';
 import QuestionItem from './QuestionItem';
 
@@ -6,19 +7,23 @@ interface QuestionListProps {
   questions: IQuestionItem[];
 }
 
-const QuestionList = ({ questions }: QuestionListProps) => {
+const QuestionList = forwardRef(({ questions }: QuestionListProps, ref?: Ref<HTMLLIElement>) => {
   return (
     <Container>
-      {questions.map((question) => (
-        <QuestionItem question={question} key={question.id} />
+      {questions.map((question, index) => (
+        <QuestionItem
+          question={question}
+          key={question.id}
+          ref={index === questions.length - 1 ? ref : null}
+        />
       ))}
     </Container>
   );
-};
+});
 
 export default QuestionList;
 
-const Container = styled.div`
+const Container = styled.ul`
   margin-top: 32px;
   border-top: 1px solid ${({ theme }) => theme.colors.lightGray};
 `;

--- a/src/components/domain/QuestionList/index.tsx
+++ b/src/components/domain/QuestionList/index.tsx
@@ -10,7 +10,7 @@ const QuestionList = ({ questions }: QuestionListProps) => {
   return (
     <Container>
       {questions.map((question) => (
-        <QuestionItem question={question} />
+        <QuestionItem question={question} key={question.id} />
       ))}
     </Container>
   );

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,8 +1,8 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import { DependencyList, useCallback, useRef, useState } from 'react';
 
-type AxiosFnVoid<T> = () => Promise<AxiosResponse<T>>;
-type AxiosFnParams<T, R> = (...args: [T]) => Promise<AxiosResponse<R>>;
+type AxiosFnVoid<R> = () => Promise<AxiosResponse<R>>;
+type AxiosFnParams<T, R> = (args: T) => Promise<AxiosResponse<R>>;
 
 type CallbackVoid<R> = () => Promise<AxiosResponse<R> | void>;
 type CallbackParams<T, R> = (args: T) => Promise<AxiosResponse<R> | void>;
@@ -10,11 +10,11 @@ type CallbackParams<T, R> = (args: T) => Promise<AxiosResponse<R> | void>;
 type UseAxiosReturn<T, R> = {
   isLoading: boolean;
   error: AxiosError | null;
-  request: CallbackVoid<R> & CallbackParams<T, R>;
+  request: CallbackVoid<R> | CallbackParams<T, R>;
 };
 
 const useAxios = <T, R>(
-  axiosFn: AxiosFnVoid<R> & AxiosFnParams<T, R>,
+  axiosFn: AxiosFnVoid<R> | AxiosFnParams<T, R>,
   dependency: DependencyList,
   errorHandler?: (status: number, message: string) => void,
 ): UseAxiosReturn<T, R> => {
@@ -23,7 +23,7 @@ const useAxios = <T, R>(
 
   const lastCallId = useRef(0);
 
-  const request = useCallback((...args: any) => {
+  const request = useCallback((args: T) => {
     const callId = ++lastCallId.current;
 
     if (!isLoading) {

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+interface UseIntersectionObserverProps {
+  root?: null;
+  rootMargin?: string;
+  threshold?: number;
+  onIntersect: IntersectionObserverCallback;
+}
+
+const useIntersectionObserver = ({
+  root,
+  rootMargin = '0px',
+  threshold = 0,
+  onIntersect,
+}: UseIntersectionObserverProps) => {
+  const [target, setTarget] = useState<HTMLElement | null | undefined>(null);
+
+  useEffect(() => {
+    if (!target) return;
+
+    const observer: IntersectionObserver = new IntersectionObserver(onIntersect, {
+      root,
+      rootMargin,
+      threshold,
+    });
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [onIntersect, root, rootMargin, target, threshold]);
+
+  return { setTarget };
+};
+
+export default useIntersectionObserver;

--- a/src/service/question.ts
+++ b/src/service/question.ts
@@ -44,6 +44,6 @@ export const matchQuestionPassword = (questionId: number, password: string) => {
   return unauth.post(`/questions/${questionId}/match`, { password });
 };
 
-export const getQuestionList = () => {
-  return unauth.get<QuestionListResponse>('/questions');
+export const getQuestionList = ({ category, page }: { category: string; page: number }) => {
+  return unauth.get<QuestionListResponse>(`/questions?category=${category}&page=${page}`);
 };

--- a/src/utils/constant/category.ts
+++ b/src/utils/constant/category.ts
@@ -13,4 +13,33 @@ export const middleCategories = [
   '보안',
   '운영체제',
   '자료구조/알고리즘',
+  '인프라/엔지니어링',
 ];
+
+export const categories = {
+  fe: [
+    'FE 기본',
+    'CSS',
+    'HTML',
+    'Javascript',
+    'React',
+    '네트워크',
+    '디자인패턴',
+    '보안',
+    '자료구조/알고리즘',
+  ],
+  be: [
+    'BE 기본',
+    'Java',
+    'Spring',
+    '네트워크',
+    '데이터베이스',
+    '디자인패턴',
+    '보안',
+    '운영체제',
+    '자료구조/알고리즘',
+    '인프라/엔지니어링',
+  ],
+};
+
+export type MainCategory = keyof typeof categories;

--- a/src/utils/helper/checkType.ts
+++ b/src/utils/helper/checkType.ts
@@ -1,0 +1,2 @@
+export const isString = (value: unknown): value is string =>
+  typeof value === 'string' || value instanceof String;

--- a/src/utils/helper/formatting.ts
+++ b/src/utils/helper/formatting.ts
@@ -1,0 +1,5 @@
+export const formatNumber = (num: number) => {
+  if (num < 10000) return num.toLocaleString();
+  if (num / 10000 < 10) return `${(num / 1000).toFixed(1)}만`;
+  return `${Math.floor(num / 10000)}만`;
+};


### PR DESCRIPTION
close #18

## ✅ 작업 내용
- 면접 목록 조회 API 연결
- 면접 질문 리스트 아이템 내 댓글 아이콘 추가 및 조회수 추가
- url-ui 동기화 (?dev=fe&category=전체)
- 무한 스크롤 적용

## 📌 이슈 사항
- 헤더에서 프론트엔드인지 백엔드인지 강조되는 스타일이 없습니다. 대분류가 프론트엔드이면 ('/', '/?dev=fe')이고 백엔드이면 ('/?dev=be')인데 어떻게 처리할지 고민 중입니다.

## ✍ 궁금한 점
- 우선 CSR로 만들었는데 SSR로 변경하는 게 좋을까요?
- 카테고리 상수 `middleCategories `, `categories` 값이 일부 겹치는 데 어떻게 하면 좋을까요? 지금 생각나는 방법으로는 `middleCategories` 값을 `cateogires`의 Set 하면 될 것 같습니당