### PR TITLE
Feat/#30 현재 카테고리에 맞게 이전,다음 질문 볼 수있도록 처리

### DIFF
--- a/src/components/domain/QuestionList/QuestionItem.tsx
+++ b/src/components/domain/QuestionList/QuestionItem.tsx
@@ -1,38 +1,46 @@
 import styled from '@emotion/styled';
 import Icon from '~/components/base/Icon';
 import Link from '~/components/base/Link';
-import { IQuestionItem } from '~/types/question';
+import { IQuestionItem, QuestionCategoryQuery } from '~/types/question';
 import { formatNumber } from '../../../utils/helper/formatting';
 import { forwardRef, Ref } from 'react';
 
 interface QuestionItemProps {
   question: IQuestionItem;
+  currentCategory: QuestionCategoryQuery;
 }
 
-const QuestionItem = forwardRef(({ question }: QuestionItemProps, ref?: Ref<HTMLLIElement>) => {
-  return (
-    <StyledItem ref={ref}>
-      <Link href={`/question/${question.id}`}>
-        <CategoryName title={question.category}>
-          <span>{question.category}</span>
-        </CategoryName>
-        <QuestionTitle title={question.title}>
-          <span>{question.title}</span>
-        </QuestionTitle>
-        <QuestionInfo>
-          <QuestionInfoItem title={String(question.viewCount)}>
-            <Icon name="Eye" color="darkGray" size="15" />
-            {formatNumber(question.viewCount)}
-          </QuestionInfoItem>
-          <QuestionInfoItem title={String(question.commentCount)}>
-            <Icon name="Comment" color="darkGray" size="15" />
-            {formatNumber(question.commentCount)}
-          </QuestionInfoItem>
-        </QuestionInfo>
-      </Link>
-    </StyledItem>
-  );
-});
+const QuestionItem = forwardRef(
+  ({ question, currentCategory }: QuestionItemProps, ref?: Ref<HTMLLIElement>) => {
+    return (
+      <StyledItem ref={ref}>
+        <Link
+          href={{
+            pathname: `/question/${question.id}`,
+            query: { main: currentCategory.main, sub: currentCategory.sub },
+          }}
+        >
+          <CategoryName title={question.category}>
+            <span>{question.category}</span>
+          </CategoryName>
+          <QuestionTitle title={question.title}>
+            <span>{question.title}</span>
+          </QuestionTitle>
+          <QuestionInfo>
+            <QuestionInfoItem title={String(question.viewCount)}>
+              <Icon name="Eye" color="darkGray" size="15" />
+              {formatNumber(question.viewCount)}
+            </QuestionInfoItem>
+            <QuestionInfoItem title={String(question.commentCount)}>
+              <Icon name="Comment" color="darkGray" size="15" />
+              {formatNumber(question.commentCount)}
+            </QuestionInfoItem>
+          </QuestionInfo>
+        </Link>
+      </StyledItem>
+    );
+  },
+);
 
 export default QuestionItem;
 

--- a/src/components/domain/QuestionList/index.tsx
+++ b/src/components/domain/QuestionList/index.tsx
@@ -1,25 +1,29 @@
 import styled from '@emotion/styled';
 import { forwardRef, Ref } from 'react';
-import { IQuestionItem } from '~/types/question';
+import { IQuestionItem, QuestionCategoryQuery } from '~/types/question';
 import QuestionItem from './QuestionItem';
 
 interface QuestionListProps {
   questions: IQuestionItem[];
+  currentCategory: QuestionCategoryQuery;
 }
 
-const QuestionList = forwardRef(({ questions }: QuestionListProps, ref?: Ref<HTMLLIElement>) => {
-  return (
-    <Container>
-      {questions.map((question, index) => (
-        <QuestionItem
-          question={question}
-          key={question.id}
-          ref={index === questions.length - 1 ? ref : null}
-        />
-      ))}
-    </Container>
-  );
-});
+const QuestionList = forwardRef(
+  ({ questions, currentCategory }: QuestionListProps, ref?: Ref<HTMLLIElement>) => {
+    return (
+      <Container>
+        {questions.map((question, index) => (
+          <QuestionItem
+            question={question}
+            key={question.id}
+            ref={index === questions.length - 1 ? ref : null}
+            currentCategory={currentCategory}
+          />
+        ))}
+      </Container>
+    );
+  },
+);
 
 export default QuestionList;
 

--- a/src/components/domain/question/MoveButtons/index.tsx
+++ b/src/components/domain/question/MoveButtons/index.tsx
@@ -1,20 +1,22 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { ReactNode } from 'react';
 import Button from '~/components/base/Button';
 import Icon from '~/components/base/Icon';
+import { QuestionCategoryQuery } from '~/types/question';
 
 interface MoveButtonProps {
+  categoryQuery: QuestionCategoryQuery;
   prevId: number;
   nextId: number;
 }
 
-const MoveButtons = ({ nextId, prevId }: MoveButtonProps) => {
+const MoveButtons = ({ categoryQuery, nextId, prevId }: MoveButtonProps) => {
   const router = useRouter();
+  const { main, sub } = categoryQuery;
 
   const onMovePrev = () => {
     if (prevId) {
-      router.push(`/question/${prevId}`);
+      router.push(`/question/${prevId}?main=${main}&sub=${sub}`);
     } else {
       alert('첫 번째 페이지 입니다.');
     }
@@ -22,7 +24,7 @@ const MoveButtons = ({ nextId, prevId }: MoveButtonProps) => {
 
   const onMoveNext = () => {
     if (nextId) {
-      router.push(`/question/${nextId}`);
+      router.push(`/question/${nextId}?main=${main}&sub=${sub}`);
     } else {
       alert('마지막 페이지 입니다.');
     }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,13 +109,19 @@ const Home: NextPage = () => {
       </Head>
       <MainContent>
         {router.isReady && selectedCategories && (
-          <MiddleCategory
-            categories={['전체', ...categories[selectedCategories.main]]}
-            onSelect={onChangeSubCategory}
-            currentCategory={selectedCategories.sub}
-          />
+          <>
+            <MiddleCategory
+              categories={['전체', ...categories[selectedCategories.main]]}
+              onSelect={onChangeSubCategory}
+              currentCategory={selectedCategories.sub}
+            />
+            <QuestionList
+              ref={setObserverTarget}
+              questions={questions}
+              currentCategory={{ main: selectedCategories.main, sub: selectedCategories.sub }}
+            />
+          </>
         )}
-        <QuestionList ref={setObserverTarget} questions={questions} />
       </MainContent>
     </div>
   );

--- a/src/pages/question/[id].tsx
+++ b/src/pages/question/[id].tsx
@@ -1,71 +1,45 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 import PageContainer from '~/components/common/PageContainer';
 import styled from '@emotion/styled';
 import AdditionalQuestions from '~/components/domain/question/AdditionalQuestions';
 import PostHeader from '~/components/domain/question/PostHeader';
 import Comment from '~/components/common/Comment';
-import { ICommentItem } from '~/types/comment';
-import useTimer from '~/hooks/useTimer';
-import Button from '~/components/base/Button';
-import Icon from '~/components/base/Icon';
-import MainContainer from '~/components/common/MainContainer';
 import { getQuestionDetail } from '~/service/question';
 import { NextPageContext } from 'next';
-import { IQuestionDetail } from '~/types/question';
-import { useRouter } from 'next/router';
+import { IQuestionDetail, QuestionCategoryQuery } from '~/types/question';
 import MoveButtons from '~/components/domain/question/MoveButtons';
 import Recorder from '~/components/domain/question/Recorder';
-
-const commentData: ICommentItem[] = [
-  {
-    id: 1,
-    nickname: '하이루',
-    content: '반가워요~',
-    createdAt: '2022.09.28 00:00:00',
-  },
-  {
-    id: 2,
-    nickname: '하이루2',
-    content: '반가워요~2',
-    createdAt: '2022.09.28 00:00:00',
-  },
-  {
-    id: 3,
-    nickname: '하이루3',
-    content: '반가워요~3',
-    createdAt: '2022.09.28 00:00:00',
-  },
-];
+import { formatCategory } from '~/utils/helper/formatting';
+import { isString } from '~/utils/helper/checkType';
 
 /*
 
-1. [녹음 시작버튼] 클릭 시 시간을 카운트 한다.
-2. 60초가되면 녹음을 자동으로 멈추고 카운트도 멈춘다
-   [녹음 중지] 버튼을 눌렀을 경우 카운트를 멈춘다.
-
-3. 녹음이 중지되었을 경우 [재생 버튼]이 활성화 된다.
-4. 재생 버튼을 클릭 할 경우 0에서 지정한 카운트 만큼 시간이 표시 되고
-   녹음된 내용이 재생된다.
-5. 다시 재생 버튼을 누를 경우 다시 0에서 지정한 카운트 만큼 표시되면서 진행상황을 알려준다.
-6. 만약 다시 녹음 버튼을 누른다면 지정한 카운트가 초기화 되고 재생 버튼이 비활성화 되고,
-   녹음이 다시 시작된다.
+TODO: progress UI 처리
 
 */
 
 export const getServerSideProps = async (context: NextPageContext) => {
-  const { id } = context.query;
+  const { id, main, sub } = context.query;
   const questionId = Number(id);
 
-  if (Number.isNaN(questionId)) {
+  if (!isString(id) || !isString(main) || !isString(sub)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const category = formatCategory(main, sub);
+
+  if (Number.isNaN(questionId) || !category) {
     return {
       notFound: true,
     };
   }
 
   try {
-    const response = await getQuestionDetail(questionId);
+    const response = await getQuestionDetail(questionId, category);
     return {
-      props: { detailData: response.data || null },
+      props: { detailData: response.data || null, query: { main, sub } },
     };
   } catch (e) {
     return {
@@ -76,9 +50,10 @@ export const getServerSideProps = async (context: NextPageContext) => {
 
 interface QuestionDetailProps {
   detailData: IQuestionDetail;
+  query: QuestionCategoryQuery;
 }
 
-const QuestionDetail = ({ detailData }: QuestionDetailProps) => {
+const QuestionDetail = ({ detailData, query }: QuestionDetailProps) => {
   return (
     <Container>
       <PostHeader
@@ -89,7 +64,7 @@ const QuestionDetail = ({ detailData }: QuestionDetailProps) => {
       <PostContent>
         <Recorder />
         <AdditionalQuestions questions={detailData.additionQuestions} />
-        <MoveButtons prevId={detailData.prevId} nextId={detailData.nextId} />
+        <MoveButtons categoryQuery={query} prevId={detailData.prevId} nextId={detailData.nextId} />
       </PostContent>
       <Comment questionId={detailData.id} />
     </Container>

--- a/src/service/question.ts
+++ b/src/service/question.ts
@@ -32,8 +32,8 @@ export const deleteQuestion = (questionId: number, password: string) => {
   return unauth.delete(`/questions/${questionId}`, { data: { password } });
 };
 
-export const getQuestionDetail = (questionId: number) => {
-  return unauth.get<QuestionDetailResponse>(`/questions/${questionId}`);
+export const getQuestionDetail = (questionId: number, category: string) => {
+  return unauth.get<QuestionDetailResponse>(`/questions/${questionId}?category=${category}`);
 };
 
 export const editQuestion = (questionId: number, question: Omit<IQuestion, 'nickname'>) => {

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -33,3 +33,9 @@ export interface IQuestionDetail {
   prevId: number;
   nextId: number;
 }
+
+// 카테고리 확정되면 좀 더 세부적으로 타입 지정
+export interface QuestionCategoryQuery {
+  main: string;
+  sub: string;
+}

--- a/src/utils/helper/formatting.ts
+++ b/src/utils/helper/formatting.ts
@@ -12,3 +12,12 @@ export const formatDate = (date: string) => {
 export const formatTime = (minutes: number, seconds: number) => {
   return `${minutes}:${seconds < 10 ? 0 : ''}${seconds}`;
 };
+
+export const formatCategory = (mainCategory: string, subCategory: string) => {
+  if (subCategory === '전체') {
+    return mainCategory === 'fe' ? 'FE ALL' : 'BE ALL';
+  }
+
+  // 카테고리 완성되면 카테고리에 포함되지 않은 query입력 시 null 반환하도록 변경
+  return subCategory;
+};


### PR DESCRIPTION
close #30 

## ✅ 작업 내용
- 질문 리스트 클릭 시 query를 통해 현재 카테고리 정보를 전달하여 category에 맞게 이전, 다음 질문이 나타나도록 하였습니다.
- 질문 상세페이지에서 버튼 시에도 카테고리 정보를 함께 전달하도록 하였습니다.

## 📌 이슈 사항
- 카테고리가 아직 확정되지 않아서 일단 테스트를 위한 기능 구현만 된 상태입니다. 내일 완료되면 다시 수정해서 머지 할 계획입니다.

## ✍ 궁금한 점
- 카테고리가 확정되지 않아서 formatCategory 함수를 완성시키지는 않았는데, 소문자로된 카테고리명을 전달 시 클라이언트에서 표시될 카테고리명을 반환 + 카테고리 리스트에 없을 경우 null을 반환하여 처리하는 함수로 계획을 했습니다.
기존 것이랑 통일하고 싶어서 함수명 저렇게 적었는데 괜찮나요?