### PR TITLE
Feat/#29 메인페이지 SSR 적용

### DIFF
--- a/src/components/common/Header/CategoryListItem.tsx
+++ b/src/components/common/Header/CategoryListItem.tsx
@@ -5,12 +5,15 @@ interface CategoryListItemProps {
   href: string;
   name: string;
   select: boolean;
+  shallow?: boolean;
 }
 
-const CategoryListItem = ({ href, name, select }: CategoryListItemProps) => {
+const CategoryListItem = ({ href, name, select, shallow = false }: CategoryListItemProps) => {
   return (
     <Li className={select ? 'selected' : ''}>
-      <Link href={href}>{name}</Link>
+      <Link href={href} shallow={shallow}>
+        {name}
+      </Link>
     </Li>
   );
 };

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -39,11 +39,13 @@ const Header = () => {
               href="/?mainCategory=fe"
               select={selectedCategory === 'fe'}
               name="프론트엔드"
+              shallow
             />
             <CategoryListItem
               href="/?mainCategory=be"
               select={selectedCategory === 'be'}
               name="백엔드"
+              shallow
             />
           </CategoryList>
         </LeftArea>

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -15,16 +15,10 @@ const Header = () => {
     }
 
     if (router.pathname === '/') {
-      if (router.query.mainCategory === 'fe' || !router.query.mainCategory) {
-        setSelectedCategory('fe');
-        return;
-      }
-      if (router.query.mainCategory === 'be') {
-        setSelectedCategory('be');
-        return;
-      }
+      setSelectedCategory(router.query.mainCategory === 'be' ? 'be' : 'fe');
+    } else {
+      setSelectedCategory('');
     }
-    setSelectedCategory('');
   }, [router.isReady, router.query]);
 
   return (

--- a/src/components/domain/QuestionList/QuestionItem.tsx
+++ b/src/components/domain/QuestionList/QuestionItem.tsx
@@ -21,7 +21,7 @@ const QuestionItem = forwardRef(
             query: { ...currentCategory },
           }}
         >
-          <CategoryName title={question.subCategory}>
+          <CategoryName title={convertSubCategory(question.subCategory)}>
             <span>{convertSubCategory(question.subCategory)}</span>
           </CategoryName>
           <QuestionTitle title={question.title}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -69,7 +69,8 @@ const Home: NextPage<HomeProps> = (homeData) => {
   const [isEndPage, setIsEndPage] = useState(homeData.isEndPage);
 
   const router = useRouter();
-  const { isLoading, request } = useAxios(getQuestionList, [queryParams]);
+  const { request } = useAxios(getQuestionList, [queryParams]);
+  const [isLoading, setIsLoading] = useState(false);
 
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isEndPage) {
@@ -78,7 +79,9 @@ const Home: NextPage<HomeProps> = (homeData) => {
     }
 
     if (isIntersecting && !isLoading) {
-      setQueryParams({ ...queryParams, page: queryParams.page + 1 });
+      const nextQueryParams = { ...queryParams, page: queryParams.page + 1 };
+      setQueryParams(nextQueryParams);
+      requestQuestionList(nextQueryParams);
     }
   };
   const { setTarget: setObserverTarget } = useIntersectionObserver({ onIntersect, threshold: 0.2 });
@@ -86,8 +89,9 @@ const Home: NextPage<HomeProps> = (homeData) => {
   const onChangeSubCategory = (subCategory: SubWithAllType) => {
     if (queryParams.subCategory === subCategory) return;
 
-    setQueryParams({ ...queryParams, subCategory, page: initialValues.page });
+    const nextQueryParams = { ...queryParams, subCategory, page: initialValues.page };
     setIsEndPage(false);
+    setQueryParams(nextQueryParams);
     router.push(
       {
         pathname: '/',
@@ -96,9 +100,11 @@ const Home: NextPage<HomeProps> = (homeData) => {
       undefined,
       { shallow: true },
     );
+    requestQuestionList(nextQueryParams);
   };
 
-  const requestQuestionList = async () => {
+  const requestQuestionList = async (queryParams: QueryParams) => {
+    setIsLoading(true);
     const result = await request(queryParams);
     if (!result) return;
 
@@ -111,11 +117,8 @@ const Home: NextPage<HomeProps> = (homeData) => {
     if (result.data.last) {
       setIsEndPage(true);
     }
+    setIsLoading(false);
   };
-
-  useEffect(() => {
-    requestQuestionList();
-  }, [request]);
 
   useEffect(() => {
     const { query } = router;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import PageContainer from '~/components/common/PageContainer';
 import QuestionList from '~/components/domain/QuestionList';
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router';
 import { isMainType, isSubWithAllType } from '~/utils/helper/checkType';
 import useIntersectionObserver from '~/hooks/useIntersectionObserver';
 import { MainType, SubWithAllType, SUB_CATEGORIES } from '~/utils/constant/category';
+import { isValidCategoryPair } from '../utils/helper/validation';
 
 type QueryParams = {
   mainCategory: MainType;
@@ -25,10 +26,47 @@ const initialValues: QueryParams = {
   page: 0,
 };
 
-const Home: NextPage = () => {
-  const [queryParams, setQueryParams] = useState<QueryParams>();
-  const [questions, setQuestions] = useState<IQuestionItem[]>([]);
-  const [isEndPage, setIsEndPage] = useState(false);
+interface HomeProps {
+  queryParams: QueryParams;
+  questions: IQuestionItem[];
+  isEndPage: boolean;
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { query } = context;
+  query.subCategory = query.subCategory ?? 'all';
+  const queryParams = { ...initialValues };
+
+  if (
+    isMainType(query.mainCategory) &&
+    isSubWithAllType(query.subCategory) &&
+    isValidCategoryPair(query.mainCategory, query.subCategory)
+  ) {
+    queryParams.mainCategory = query.mainCategory;
+    queryParams.subCategory = query.subCategory;
+  }
+
+  try {
+    const { data } = await getQuestionList(queryParams);
+    return {
+      props: {
+        queryParams,
+        questions: data.content,
+        isEndPage: data.last,
+      },
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      notFound: true,
+    };
+  }
+};
+
+const Home: NextPage<HomeProps> = (homeData) => {
+  const [queryParams, setQueryParams] = useState<QueryParams>(homeData.queryParams);
+  const [questions, setQuestions] = useState<IQuestionItem[]>(homeData.questions);
+  const [isEndPage, setIsEndPage] = useState(homeData.isEndPage);
 
   const router = useRouter();
   const { isLoading, request } = useAxios(getQuestionList, [queryParams]);
@@ -39,37 +77,39 @@ const Home: NextPage = () => {
       return;
     }
 
-    if (isIntersecting && !isLoading && queryParams) {
+    if (isIntersecting && !isLoading) {
       setQueryParams({ ...queryParams, page: queryParams.page + 1 });
     }
   };
   const { setTarget: setObserverTarget } = useIntersectionObserver({ onIntersect, threshold: 0.2 });
 
   const onChangeSubCategory = (subCategory: SubWithAllType) => {
-    if (!queryParams || queryParams.subCategory === subCategory) return;
+    if (queryParams.subCategory === subCategory) return;
 
     setQueryParams({ ...queryParams, subCategory, page: initialValues.page });
     setIsEndPage(false);
-    router.push({
-      pathname: '/',
-      query: { mainCategory: queryParams.mainCategory, subCategory },
-    });
+    router.push(
+      {
+        pathname: '/',
+        query: { mainCategory: queryParams.mainCategory, subCategory },
+      },
+      undefined,
+      { shallow: true },
+    );
   };
 
   const requestQuestionList = async () => {
-    if (!router.isReady || !queryParams) return;
-
     const result = await request(queryParams);
-    if (result) {
-      setQuestions(
-        queryParams.page === initialValues.page
-          ? result.data.content
-          : [...questions, ...result.data.content],
-      );
+    if (!result) return;
 
-      if (result.data.last) {
-        setIsEndPage(true);
-      }
+    setQuestions(
+      queryParams.page === initialValues.page
+        ? result.data.content
+        : [...questions, ...result.data.content],
+    );
+
+    if (result.data.last) {
+      setIsEndPage(true);
     }
   };
 
@@ -78,23 +118,26 @@ const Home: NextPage = () => {
   }, [request]);
 
   useEffect(() => {
-    if (!router.isReady) return;
+    const { query } = router;
+    query.subCategory = query.subCategory ?? 'all';
+    const nextQueryParams = { ...initialValues };
 
-    let { mainCategory, subCategory } = router.query;
-
-    if (!isMainType(mainCategory)) mainCategory = initialValues.mainCategory;
-    if (!isSubWithAllType(subCategory)) subCategory = initialValues.subCategory;
+    if (
+      isMainType(query.mainCategory) &&
+      isSubWithAllType(query.subCategory) &&
+      isValidCategoryPair(query.mainCategory, query.subCategory)
+    ) {
+      nextQueryParams.mainCategory = query.mainCategory;
+      nextQueryParams.subCategory = query.subCategory;
+    }
 
     const notChanged =
-      mainCategory === queryParams?.mainCategory && subCategory === queryParams?.subCategory;
+      query.mainCategory === queryParams.mainCategory &&
+      query.subCategory === queryParams.subCategory;
     if (notChanged) return;
 
-    setQueryParams({
-      mainCategory: mainCategory as MainType,
-      subCategory: subCategory as SubWithAllType,
-      page: initialValues.page,
-    });
-  }, [router.isReady, router.query.mainCategory, router.query.subCategory]);
+    setQueryParams(nextQueryParams);
+  }, [router.query.mainCategory, router.query.subCategory]);
 
   return (
     <div>
@@ -104,23 +147,21 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <MainContent>
-        {router.isReady && queryParams && (
-          <>
-            <MiddleCategory
-              subCategories={['all', ...SUB_CATEGORIES[queryParams.mainCategory]]}
-              onSelect={onChangeSubCategory}
-              currentCategory={queryParams.subCategory}
-            />
-            <QuestionList
-              ref={setObserverTarget}
-              questions={questions}
-              currentCategory={{
-                mainCategory: queryParams.mainCategory,
-                subCategory: queryParams.subCategory,
-              }}
-            />
-          </>
-        )}
+        <>
+          <MiddleCategory
+            subCategories={['all', ...SUB_CATEGORIES[queryParams.mainCategory]]}
+            onSelect={onChangeSubCategory}
+            currentCategory={queryParams.subCategory}
+          />
+          <QuestionList
+            ref={setObserverTarget}
+            questions={questions}
+            currentCategory={{
+              mainCategory: queryParams.mainCategory,
+              subCategory: queryParams.subCategory,
+            }}
+          />
+        </>
       </MainContent>
     </div>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ import { useRouter } from 'next/router';
 import { isMainType, isSubWithAllType } from '~/utils/helper/checkType';
 import useIntersectionObserver from '~/hooks/useIntersectionObserver';
 import { MainType, SubWithAllType, SUB_CATEGORIES } from '~/utils/constant/category';
-import { isValidCategoryPair } from '../utils/helper/validation';
+import { isValidCategoryPair } from '~/utils/helper/validation';
 
 type QueryParams = {
   mainCategory: MainType;
@@ -140,6 +140,7 @@ const Home: NextPage<HomeProps> = (homeData) => {
     if (notChanged) return;
 
     setQueryParams(nextQueryParams);
+    requestQuestionList(nextQueryParams);
   }, [router.query.mainCategory, router.query.subCategory]);
 
   return (

--- a/src/utils/helper/validation.ts
+++ b/src/utils/helper/validation.ts
@@ -1,3 +1,5 @@
+import { MainType, SubType, SubWithAllType, SUB_CATEGORIES } from '../constant/category';
+
 export const checkLength = (str: string, min: number, max: number) => {
   return str.length < min || str.length > max ? true : false;
 };
@@ -45,4 +47,8 @@ export const SUBMIT_CHECK = {
     isValid: checkTitle,
     message: '질문 제목은 2~30자로 입력해 주세요.',
   },
+};
+
+export const isValidCategoryPair = (main: MainType, sub: SubWithAllType) => {
+  return sub === 'all' || (SUB_CATEGORIES[main] as ReadonlyArray<SubType>).includes(sub);
 };


### PR DESCRIPTION
close #29 

## ✅ 작업 내용
- 메인페이지 SSR 적용
- 메인페이지로 router.push 하는 곳들 shallow 옵션 추가
- 메인페이지에서 질문의 중분류의 title속성 값이 카테고리 코드인 문제 수정
- main/subCategory 관계가 올바른지 검증하는 유틸함수 추가

## 📌 이슈 사항
- ~무한스크롤 버그 찾아서 수정 중..;;~
  - (`useAxios`)API 통신에 대한 `isLoading`이 무한스크롤에 사용되는 `setIsEndPage` 호출 전에 `false`값으로 변경되어서 발생한 버그

## ✍ 궁금한 점
- 이상한 query parameter로 접근하면 무시하고 `mainCategory=fe&subCategory=all`로 보여주는데 자연스러워 보이나요?