### PR TITLE
Feat/#47 건의하기 페이지 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,9 @@ const nextConfig = {
   },
   env: {
     BASE_URL: process.env.BASE_URL,
+    EMAILJS_SERVICE_ID: process.env.EMAILJS_SERVICE_ID,
+    EMAILJS_TEMPLATE_ID: process.env.EMAILJS_TEMPLATE_ID,
+    EMAILJS_PUBLIC_KEY: process.env.EMAILJS_PUBLIC_KEY,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "axios": "^0.27.2",
+    "emailjs-com": "^3.2.0",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -3,12 +3,12 @@ import { theme } from '~/types/theme';
 export const buttonStyle = {
   black: `
     background-color: ${theme.colors.gray700};
-    color: white;
+    color: ${theme.colors.white};
     border-radius: 4px;
   `,
   borderGray: `
     border: 1px solid ${theme.colors.gray300};
-    background-color: white;
+    background-color: ${theme.colors.white};
     color: ${theme.colors.gray600};
     border-radius: 4px;
 
@@ -16,14 +16,28 @@ export const buttonStyle = {
       background-color: ${theme.colors.gray100};
     }
   `,
+  gray: `
+    background-color: ${theme.colors.gray500};
+    color: ${theme.colors.white};
+    border-radius: 4px;
+
+    &:hover {
+      background-color: ${theme.colors.gray600};
+    }
+  `,
   red: `
     background-color: ${theme.colors.red};
-    color: white;
+    color: ${theme.colors.white};
     border-radius: 4px;
   `,
 };
 
 export const buttonSizes = {
+  xs: `
+    font-size: 12px;
+    padding: 4px 10px;
+    line-height: 20px;
+  `,
   sm: `
     ${theme.fontStyle.body2}
     padding: 8px 12px;

--- a/src/components/base/Link.tsx
+++ b/src/components/base/Link.tsx
@@ -4,7 +4,10 @@ import { ReactNode } from 'react';
 import { buttonSizes, buttonStyle } from './Button/types';
 
 type LinkTypes = { linkType?: keyof typeof buttonStyle; size?: keyof typeof buttonSizes };
-type LinkProps = Omit<NextLinkProps, 'passHref'> & { children: ReactNode } & LinkTypes;
+type LinkProps = Omit<NextLinkProps, 'passHref'> & {
+  children: ReactNode;
+  className?: string;
+} & LinkTypes;
 
 const Link = ({
   linkType,
@@ -17,6 +20,7 @@ const Link = ({
   locale,
   children,
   onClick,
+  className,
   ...props
 }: LinkProps) => {
   return (
@@ -30,7 +34,7 @@ const Link = ({
       passHref
       {...props}
     >
-      <StyledA linkType={linkType} size={size} onClick={onClick}>
+      <StyledA linkType={linkType} size={size} onClick={onClick} className={className}>
         {children}
       </StyledA>
     </NextLink>

--- a/src/components/common/ErrorMessage/index.tsx
+++ b/src/components/common/ErrorMessage/index.tsx
@@ -23,6 +23,7 @@ export default ErrorMessage;
 const Message = styled.p`
   display: flex;
   margin-top: 8px;
+  align-items: center;
 
   span {
     margin-left: 4px;

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -1,0 +1,48 @@
+import styled from '@emotion/styled';
+import Button from '~/components/base/Button';
+import Link from '~/components/base/Link';
+import PageContainer from '../PageContainer';
+
+const Footer = () => {
+  return (
+    <FooterContainer>
+      <Inner>
+        <LogoArea>
+          <Logo>developerwiki</Logo>
+          <SuggestionButton href="/suggestion" size="xs" linkType="gray">
+            건의하기
+          </SuggestionButton>
+        </LogoArea>
+        <Copyright> Copyright © developerwiki. All rights reserved.</Copyright>
+      </Inner>
+    </FooterContainer>
+  );
+};
+
+export default Footer;
+
+const FooterContainer = styled.footer`
+  background-color: ${({ theme }) => theme.colors.gray100};
+`;
+
+const Inner = styled(PageContainer)`
+  padding: 45px 0 45px;
+`;
+
+const SuggestionButton = styled(Link)`
+  margin-left: 12px;
+`;
+
+const Logo = styled.h4`
+  font-size: 20px;
+`;
+
+const Copyright = styled.p`
+  margin-top: 8px;
+  color: ${({ theme }) => theme.colors.gray500};
+  ${({ theme }) => theme.fontStyle.caption};
+`;
+
+const LogoArea = styled.div`
+  display: flex;
+`;

--- a/src/components/common/InputField/TitleField.tsx
+++ b/src/components/common/InputField/TitleField.tsx
@@ -1,0 +1,28 @@
+import { ChangeEvent } from 'react';
+import Input from '~/components/base/Input';
+import Label from '~/components/base/Label';
+import InputField from '.';
+import ErrorMessage from '../ErrorMessage';
+
+interface TitleFieldProps {
+  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  message?: string;
+}
+
+const TitleField = ({ handleChange, message }: TitleFieldProps) => {
+  return (
+    <InputField>
+      <Label htmlFor="title">제목</Label>
+      <Input
+        type="text"
+        name="title"
+        id="title"
+        placeholder="질문 제목을 입력해 주세요."
+        onChange={handleChange}
+      />
+      {message && <ErrorMessage message={message} />}
+    </InputField>
+  );
+};
+
+export default TitleField;

--- a/src/components/common/InputField/index.tsx
+++ b/src/components/common/InputField/index.tsx
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+const InputField = styled.div`
+  margin-bottom: 42px;
+`;
+
+export default InputField;

--- a/src/components/common/PageDescription/index.tsx
+++ b/src/components/common/PageDescription/index.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+const PageDescription = styled.p`
+  color: ${({ theme }) => theme.colors.gray600};
+  ${({ theme }) => theme.fontStyle.body2};
+  text-align: center;
+  margin-top: 14px;
+`;
+
+export default PageDescription;

--- a/src/components/common/TextArea/index.tsx
+++ b/src/components/common/TextArea/index.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { TextareaHTMLAttributes } from 'react';
+
+interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  height?: number;
+  block?: boolean;
+}
+
+const TextArea = ({ height = 74, block = false, ...props }: TextAreaProps) => {
+  return <StyledTextArea height={height} block={block} {...props} />;
+};
+
+export default TextArea;
+
+const StyledTextArea = styled.textarea<TextAreaProps>`
+  background-color: white;
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 4px;
+  ${({ theme }) => theme.fontStyle.body2};
+  display: ${({ block }) => (block ? 'block' : 'inline-block')};
+
+  height: ${({ height }) => height && height + 'px'};
+  padding: 8px;
+  box-sizing: border-box;
+  resize: none;
+`;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@emotion/react';
 import { theme } from '~/types/theme';
 import Header from '~/components/common/Header';
 import MainContainer from '~/components/common/MainContainer';
+import Footer from '~/components/common/Footer';
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
   import('../mocks');
@@ -18,6 +19,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <MainContainer>
         <Component {...pageProps} />
       </MainContainer>
+      <Footer />
     </ThemeProvider>
   );
 }

--- a/src/pages/suggestion/index.tsx
+++ b/src/pages/suggestion/index.tsx
@@ -1,0 +1,107 @@
+import { ChangeEvent, FormEvent, useState } from 'react';
+import PageTitle from '~/components/base/PageTitle';
+import Article from '~/components/common/Article';
+import { send } from 'emailjs-com';
+import Label from '~/components/base/Label';
+import TitleField from '~/components/common/InputField/TitleField';
+import styled from '@emotion/styled';
+import TextArea from '~/components/common/TextArea';
+import Button from '~/components/base/Button';
+import InputField from '~/components/common/InputField';
+import useForm from '~/hooks/useForm';
+import { SUBMIT_CHECK } from '~/utils/helper/validation';
+import ErrorMessage from '~/components/common/ErrorMessage';
+import { useRouter } from 'next/router';
+import PageDescription from '~/components/common/PageDescription';
+
+const SERVICE_ID = process.env.EMAILJS_SERVICE_ID;
+const TEMPLATE_ID = process.env.EMAILJS_TEMPLATE_ID;
+const PUBLIC_KEY = process.env.EMAILJS_PUBLIC_KEY;
+
+const initialValues = {
+  title: '',
+  content: '',
+};
+
+type valuesType = {
+  [key in keyof typeof initialValues]: string;
+};
+
+const validate = (values: valuesType) => {
+  const errors = {} as valuesType;
+
+  if (SUBMIT_CHECK.title.isValid(values.title)) {
+    errors.title = SUBMIT_CHECK.title.message;
+  }
+
+  if (SUBMIT_CHECK.suggestion.isValid(values.content)) {
+    errors.content = SUBMIT_CHECK.suggestion.message;
+  }
+
+  return errors;
+};
+
+const Suggestion = () => {
+  const { values, errors, handleChange, handleSubmit } = useForm({
+    initialValues,
+    onSubmit,
+    validate,
+  });
+
+  const router = useRouter();
+
+  async function onSubmit() {
+    if (!SERVICE_ID || !TEMPLATE_ID || !PUBLIC_KEY) {
+      alert('메일 전송에 실패하였습니다.');
+      return;
+    }
+
+    const response = await send(SERVICE_ID, TEMPLATE_ID, values, PUBLIC_KEY);
+
+    if (response.status === 200) {
+      alert('메일이 전송되었습니다.');
+      router.push('/');
+    } else {
+      alert('메일 전송에 실패하였습니다.');
+    }
+  }
+
+  return (
+    <Article>
+      <PageTitle>건의하기</PageTitle>
+      <PageDescription>
+        Developerwiki가 더 나은 서비스로 성장할 수 있도록
+        <br />
+        아낌없는 피드백 부탁드립니다. 🙏‍
+      </PageDescription>
+
+      <Form onSubmit={handleSubmit}>
+        <TitleField handleChange={handleChange} message={errors.title} />
+        <InputField>
+          <Label htmlFor="content">건의 내용</Label>
+          <TextArea
+            height={150}
+            name="content"
+            placeholder="건의 내용을 입력해 주세요."
+            onChange={handleChange}
+            block
+          />
+          {errors.content && <ErrorMessage message={errors.content} />}
+        </InputField>
+        <SubmitButton>건의 메일 보내기</SubmitButton>
+      </Form>
+    </Article>
+  );
+};
+
+export default Suggestion;
+
+const Form = styled.form`
+  margin-top: 38px;
+`;
+
+const SubmitButton = styled(Button)`
+  display: block;
+  width: fit-content;
+  margin: 0 auto;
+`;

--- a/src/utils/helper/validation.ts
+++ b/src/utils/helper/validation.ts
@@ -34,6 +34,10 @@ export const checkTailQuestion = (text: string) => {
   return checkLength(text, 2, 30);
 };
 
+export const checkSuggestion = (text: string) => {
+  return checkLength(text, 10, 300);
+};
+
 export const SUBMIT_CHECK = {
   nickname: {
     isValid: checkNickname,
@@ -54,6 +58,10 @@ export const SUBMIT_CHECK = {
   tailQuestion: {
     isValid: checkTailQuestion,
     message: '꼬리 질문은 2~30자로 입력해 주세요.',
+  },
+  suggestion: {
+    isValid: checkSuggestion,
+    message: '내용은 10자 이상 300자 이하로 입력해 주세요.',
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,6 +2098,11 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.279.tgz#84267fec806a8b1c5a1daebf726c4e296e5bcdf9"
   integrity sha512-xs7vEuSZ84+JsHSTFqqG0TE3i8EAivHomRQZhhcRvsmnjsh5C2KdhwNKf4ZRYtzq75wojpFyqb62m32Oam57wA==
 
+emailjs-com@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/emailjs-com/-/emailjs-com-3.2.0.tgz#a53cb22f1bc433c701c84c53d8b56eefd5ce7111"
+  integrity sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"


### PR DESCRIPTION
close #47 

## ✅ 작업 내용
- 건의하기 페이지 구현했습니다.
- Footer 컴포넌트 구현하여 적용하였습니다.
- email 전송을 위해 EmailJS를 사용했습니다.

```
{
  title: "건의합니다",
  content: "로그인 기능이 있으면 좋겠습니다."
}
```
![image](https://user-images.githubusercontent.com/81489300/196504995-88343415-b0c6-440a-a277-900ef4be3717.png)
- 템플릿은 일단 기본 템플릿으로 두었고 이메일도 일단 제 이메일로 해두었습니다.


## 📌 이슈 사항
- 건의하기 버튼 때문에 xs을 추가했는데 12px은 xs버튼 외에 페이지에서 사용하진 않을 것 같아서 fontStyle추가는 하지 않았습니다. (혹시 작게 느껴지시나요??)

## ✍ 궁금한 점
- TitleFiled 컴포넌트를 만들면서 InputFiled 파일 안에 넣긴 했는데, 이렇게 파일 안에서 관리를 할지 관련 있는 페이지 (ex: domain/question)안에서 관리를 할지 고민이 되었습니다,,
- 