### PR TITLE
Feat/#45 자유 면접 연습 페이지 구현

### DIFF
--- a/src/components/domain/random/StepOne.tsx
+++ b/src/components/domain/random/StepOne.tsx
@@ -24,11 +24,12 @@ const StepOne = ({ step, inputValues, handleChange, handleSubmit, mounted }: Ste
     <>
       <Title>랜덤 질문</Title>
 
-      <Form action="submit" onSubmit={handleSubmit}>
+      <form action="submit" onSubmit={handleSubmit}>
         <TypeField
           type={inputValues.type}
           handleChange={({ target }) => handleChange(target.name, target.id)}
         />
+
         <MainCategoryField
           handleChange={({ target }) => handleChange(target.name, target.value)}
           selected={inputValues.mainCategory}
@@ -49,7 +50,7 @@ const StepOne = ({ step, inputValues, handleChange, handleSubmit, mounted }: Ste
         >
           면접 연습 시작
         </StyledButton>
-      </Form>
+      </form>
     </>
   );
 };
@@ -62,14 +63,8 @@ const Title = styled.h2`
   margin-bottom: 34px;
 `;
 
-const Form = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 42px;
-`;
-
 const StyledButton = styled(Button)<{ step: number }>`
   display: block;
-  margin: calc(64px - 42px) auto 0;
+  margin: 0 auto;
   width: fit-content;
 `;

--- a/src/components/domain/random/StepOne.tsx
+++ b/src/components/domain/random/StepOne.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { FormEvent } from 'react';
+import { FormEvent, MutableRefObject, useEffect } from 'react';
 import Button from '~/components/base/Button';
 import { InputValues, Step } from '~/pages/random/create';
 import { SubWithAllType } from '~/utils/constant/category';
@@ -12,9 +12,14 @@ interface StepOneProps {
   inputValues: InputValues;
   handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
   handleChange: (type: string, value: string | SubWithAllType[]) => void;
+  mounted: MutableRefObject<boolean>;
 }
 
-const StepOne = ({ step, inputValues, handleChange, handleSubmit }: StepOneProps) => {
+const StepOne = ({ step, inputValues, handleChange, handleSubmit, mounted }: StepOneProps) => {
+  useEffect(() => {
+    mounted.current = true;
+  }, []);
+
   return (
     <>
       <Title>랜덤 질문</Title>

--- a/src/components/domain/random/SubCategoryField.tsx
+++ b/src/components/domain/random/SubCategoryField.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { ChangeEvent } from 'react';
+import InputField from '~/components/common/InputField';
 import { MainType, SubWithAllType, SUB_CATEGORIES } from '~/utils/constant/category';
 
 import SubCategoryCheckbox from './SubCategoryCheckbox';
@@ -27,7 +28,7 @@ const SubCategoryField = ({ mainCategory, subCategories, handleChange }: SubCate
   };
 
   return (
-    <div>
+    <InputField>
       <Label htmlFor="subCategories">분류 선택</Label>
 
       {mainCategory === 'none' && <Notice>직무를 선택해주세요</Notice>}
@@ -49,7 +50,7 @@ const SubCategoryField = ({ mainCategory, subCategories, handleChange }: SubCate
           ))}
         </Container>
       )}
-    </div>
+    </InputField>
   );
 };
 

--- a/src/components/domain/random/TypeField.tsx
+++ b/src/components/domain/random/TypeField.tsx
@@ -8,7 +8,7 @@ interface TypeFieldProps {
 
 const TypeField = ({ type, handleChange }: TypeFieldProps) => {
   return (
-    <fieldset>
+    <FieldSet>
       <Legend>질문 유형</Legend>
 
       <Radio
@@ -28,11 +28,15 @@ const TypeField = ({ type, handleChange }: TypeFieldProps) => {
       <Notice>
         질문이 <strong>텍스트</strong>로 나타나며 자유롭게 답변하실 수 있습니다.
       </Notice>
-    </fieldset>
+    </FieldSet>
   );
 };
 
 export default TypeField;
+
+const FieldSet = styled.fieldset`
+  margin-bottom: 42px;
+`;
 
 const Legend = styled.legend`
   margin-bottom: 19px;

--- a/src/pages/random/create.tsx
+++ b/src/pages/random/create.tsx
@@ -56,7 +56,7 @@ const CreateRandom = () => {
     const { mainCategory, subCategories } = inputValues;
     const response = await request({
       mainCategory,
-      subCategories: subCategories.join(' '),
+      subCategory: subCategories.join(','),
     });
 
     if (!response) return;

--- a/src/pages/random/text/[idx].tsx
+++ b/src/pages/random/text/[idx].tsx
@@ -1,30 +1,179 @@
+import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Button from '~/components/base/Button';
+import Icon from '~/components/base/Icon';
+import PageContainer from '~/components/common/PageContainer';
+import PostHeader from '~/components/domain/question/PostHeader';
+import Recorder from '~/components/domain/question/Recorder';
+import TailQuestions from '~/components/domain/question/TailQuestions';
 import useStorage from '~/hooks/useStorage';
-import { QuestionDetailResponse } from '~/service/question';
+import { IQuestionDetail } from '~/types/question';
+import { isString } from '~/utils/helper/checkType';
+import { isValidRandomType } from '~/utils/helper/validation';
 
 const STORAGE_KEY = 'random';
+const DUMMY = 1;
+const DUMMY_QUESTION = {} as IQuestionDetail;
+
+type CurQuestion = IQuestionDetail & {
+  idx: number;
+};
 
 const RandomText = () => {
   const local = useStorage('local');
   const router = useRouter();
-  const { idx, mainCategory, subCategories } = router.query;
+  const recordRef = useRef<HTMLButtonElement>(null);
 
-  const [questions, setQuestions] = useState<QuestionDetailResponse[]>([]);
+  const [questions, setQuestions] = useState<IQuestionDetail[]>();
+  const [curQuestion, setCurQuestion] = useState<CurQuestion>();
+
+  const handleQuestionEnd = () => {
+    const answer = confirm('마지막 질문입니다. 종료하시겠습니까?');
+    if (!answer) return;
+
+    local.removeItem(STORAGE_KEY);
+    router.push('/');
+  };
+
+  const handlePrev = () => {
+    if (!curQuestion || !questions || curQuestion.idx === 1) {
+      alert('첫 번째 질문입니다.');
+      return;
+    }
+
+    const nextIdx = curQuestion.idx - 1;
+    setCurQuestion({ idx: nextIdx, ...questions[nextIdx] });
+    router.push(`/random/text/${nextIdx}`);
+  };
+
+  const handleNext = () => {
+    if (!curQuestion || !questions || curQuestion.idx === questions.length - 1) {
+      handleQuestionEnd();
+      return;
+    }
+
+    const nextIdx = curQuestion.idx + 1;
+    setCurQuestion({ idx: nextIdx, ...questions[nextIdx] });
+    router.push(`/random/text/${nextIdx}`);
+  };
 
   useEffect(() => {
-    const questions = local.getItem(STORAGE_KEY, []);
-    console.log(questions);
+    if (!router.isReady) return;
 
-    setQuestions(questions);
-  }, []);
+    const { idx: idxString } = router.query;
+    const idx = Number(idxString);
+
+    const random = local.getItem<{ type: string; questions: IQuestionDetail[] } | null>(
+      STORAGE_KEY,
+      null,
+    );
+
+    if (
+      !random ||
+      !isValidStoredValue(random) ||
+      !isValidIdx(idx, random.questions.length + DUMMY)
+    ) {
+      alert('잘못된 접근입니다.');
+      router.push('/');
+      return;
+    }
+
+    setQuestions([DUMMY_QUESTION, ...random.questions]);
+    setCurQuestion({ idx, ...random.questions[idx - DUMMY] });
+  }, [router.isReady]);
 
   return (
-    <div>
-      자유 연습 {idx} <br /> mainCategory: {mainCategory} <br /> subCategories:{' '}
-      {Array.isArray(subCategories) ? subCategories.join(' ') : subCategories}
-    </div>
+    <>
+      {curQuestion && (
+        <Container>
+          <PostHeader
+            subCategory={curQuestion.subCategory}
+            title={isString(curQuestion.title) ? curQuestion.title : ''}
+            writer={curQuestion.nickname}
+          />
+
+          <PostContent>
+            <Recorder ref={recordRef} key={curQuestion.idx} />
+
+            <TailQuestions
+              questions={curQuestion.tailQuestions}
+              questionId={curQuestion.id}
+              title={curQuestion.title}
+              key={curQuestion.id + curQuestion.idx}
+            />
+
+            <Buttons>
+              <PrevButton buttonType="borderGray" onClick={handlePrev}>
+                <Icon name="ArrowLeft" size="20" color="gray600" />
+                <span>이전 질문</span>
+              </PrevButton>
+              <NextButton buttonType="borderGray" onClick={handleNext}>
+                <span> 다음 질문</span>
+                <Icon name="ArrowRight" size="20" color="gray600" />
+              </NextButton>
+            </Buttons>
+          </PostContent>
+        </Container>
+      )}
+    </>
   );
 };
 
 export default RandomText;
+
+function isValidIdx(idx: number, length: number) {
+  return 0 + DUMMY <= idx && idx < length;
+}
+function isValidStoredValue(value: unknown) {
+  if (!value || typeof value !== 'object') return false;
+  const objValue = value as { type: string; questions: IQuestionDetail[] };
+
+  return (
+    'type' in objValue &&
+    isValidType(objValue.type) &&
+    'questions' in objValue &&
+    Array.isArray(objValue.questions)
+  );
+}
+function isValidType(type: unknown) {
+  return isValidRandomType(type) && type === 'text';
+}
+
+const Container = styled(PageContainer)`
+  margin-top: 32px;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 4px;
+  padding: 20px 0 50px;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const PostContent = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+
+  margin-top: 36px;
+`;
+
+const Buttons = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 60px;
+  padding: 0 36px;
+`;
+
+const PrevButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  padding-left: 16px;
+`;
+
+const NextButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  padding-right: 16px;
+`;

--- a/src/pages/random/voice/[idx].tsx
+++ b/src/pages/random/voice/[idx].tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import useStorage from '~/hooks/useStorage';
 import PostHeader from '~/components/domain/question/PostHeader';
 import { IQuestionDetail } from '~/types/question';
@@ -10,8 +10,8 @@ import PageContainer from '~/components/common/PageContainer';
 import Icon from '~/components/base/Icon';
 import { isValidRandomType } from '~/utils/helper/validation';
 import { isString } from '~/utils/helper/checkType';
+import { RANDOM_LOCAL_KEY } from '~/utils/constant/random';
 
-const STORAGE_KEY = 'random';
 const DUMMY = 1;
 const DUMMY_QUESTION = {} as IQuestionDetail;
 
@@ -28,17 +28,13 @@ const RandomVoice = () => {
   const [questions, setQuestions] = useState<IQuestionDetail[]>();
   const [curQuestion, setCurQuestion] = useState<CurQuestion>();
 
+  const clearLocal = useCallback(() => {
+    Object.values(RANDOM_LOCAL_KEY).forEach(local.removeItem);
+  }, [local]);
+
   const handleSpeechEnd = (recordRefId: number) => {
     if (recordRefId !== recordRefLastId.current) return;
     recordRef.current?.click();
-  };
-
-  const handleQuestionEnd = () => {
-    const answer = confirm('마지막 질문입니다. 종료하시겠습니까?');
-    if (!answer) return;
-
-    local.removeItem(STORAGE_KEY);
-    router.push('/');
   };
 
   const handlePrev = () => {
@@ -47,13 +43,7 @@ const RandomVoice = () => {
       return;
     }
 
-    const nextIdx = curQuestion.idx - 1;
-    setCurQuestion({ idx: nextIdx, ...questions[nextIdx] });
-    router.push(`/random/voice/${nextIdx}`);
-
-    speechSynthesis.cancel();
-    const id = ++recordRefLastId.current;
-    speak(questions[nextIdx].title, speechSynthesis, () => handleSpeechEnd(id));
+    move(curQuestion.idx - 1);
   };
 
   const handleNext = async () => {
@@ -62,8 +52,22 @@ const RandomVoice = () => {
       return;
     }
 
-    const nextIdx = curQuestion.idx + 1;
+    move(curQuestion.idx + 1);
+  };
+
+  const handleQuestionEnd = () => {
+    const answer = confirm('마지막 질문입니다. 종료하시겠습니까?');
+    if (!answer) return;
+
+    clearLocal();
+    router.push('/');
+  };
+
+  const move = (nextIdx: number) => {
+    if (!questions) return;
+
     setCurQuestion({ idx: nextIdx, ...questions[nextIdx] });
+    local.setItem(RANDOM_LOCAL_KEY.latest, nextIdx);
     router.push(`/random/voice/${nextIdx}`);
 
     speechSynthesis.cancel();
@@ -78,7 +82,7 @@ const RandomVoice = () => {
     const idx = Number(idxString);
 
     const random = local.getItem<{ type: string; questions: IQuestionDetail[] } | null>(
-      STORAGE_KEY,
+      RANDOM_LOCAL_KEY.random,
       null,
     );
 
@@ -94,6 +98,7 @@ const RandomVoice = () => {
 
     setQuestions([DUMMY_QUESTION, ...random.questions]);
     setCurQuestion({ idx, ...random.questions[idx - DUMMY] });
+    local.setItem(RANDOM_LOCAL_KEY.latest, idx);
 
     speak(random.questions[idx - DUMMY].title, speechSynthesis, () =>
       handleSpeechEnd(recordRefLastId.current),

--- a/src/pages/random/voice/[idx].tsx
+++ b/src/pages/random/voice/[idx].tsx
@@ -82,7 +82,11 @@ const RandomVoice = () => {
       null,
     );
 
-    if (!random || !isValidStoredValue(random) || !isValidIdx(idx, random.questions.length)) {
+    if (
+      !random ||
+      !isValidStoredValue(random) ||
+      !isValidIdx(idx, random.questions.length + DUMMY)
+    ) {
       alert('잘못된 접근입니다.');
       router.push('/');
       return;

--- a/src/service/question.ts
+++ b/src/service/question.ts
@@ -1,7 +1,6 @@
 import { unauth } from './base';
 import { IQuestion, IQuestionItem, ISort } from '~/types/question';
 import { MainType, SubWithAllType } from '~/utils/constant/category';
-import axios from 'axios';
 
 type QuestionListResponse = {
   content: IQuestionItem[];
@@ -57,9 +56,8 @@ export const getQuestionList = (params: {
   return unauth.get<QuestionListResponse>('/questions', { params });
 };
 
-export const getRandomQuestions = (params: { mainCategory: MainType; subCategories: string }) => {
-  // 실제 API 연결 시 unauth로 변경
-  return axios.get('/random', { params });
+export const getRandomQuestions = (params: { mainCategory: MainType; subCategory: string }) => {
+  return unauth.get('/questions/random', { params });
 };
 
 export const createTailQuestion = (questionId: number, text: string) => {

--- a/src/utils/constant/random.ts
+++ b/src/utils/constant/random.ts
@@ -1,0 +1,1 @@
+export const RANDOM_LOCAL_KEY = { random: 'random', latest: 'randomLatest' } as const;


### PR DESCRIPTION
close #45 

## ✅ 작업 내용
- 자유 면접 연습 페이지 구현
- 음성 면접 연습 페이지
  - 마지막 질문에서 새로고침 시 잘못된 접근으로 뜨는 문제 수정
- 랜덤 질문 생성 페이지
  - 진입 시 이전에 생성한 이력이 있는 경우 확인 후 리다이렉트
  - API 연결
## 📌 이슈 사항
- 랜덤 질문 생성 페이지의 첫 화면에서, 세션 스토리지 step 키의 값을 2로 변경 & stepOneValue 키의 값 제거 후 새로고침하면 안내 사항 화면으로 넘어가는 이슈가 있습니다. PR 먼저 올리고 방어 로직 생각하고 있겠습니다..
## ✍ 궁금한 점
- 가독성이 떨어지는 부분이 있다면 알려주세요!