### PR TITLE
Feat/#81 Pagination 컴포넌트 구현

### DIFF
--- a/src/assets/icons/arrow-down.svg
+++ b/src/assets/icons/arrow-down.svg
@@ -1,3 +1,4 @@
-<svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 13.5L18 22.5L27 13.5"  stroke-linecap="round" stroke="currentColor" stroke-linejoin="round"/>
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2.85714 6.42847L10 13.5713L17.1429 6.42847" stroke="currentColor" stroke-linecap="round"
+    stroke-linejoin="round" />
 </svg>

--- a/src/assets/icons/arrow-left.svg
+++ b/src/assets/icons/arrow-left.svg
@@ -1,3 +1,4 @@
-<svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M22.5 9L13.5 18L22.5 27" stroke-linecap="round" stroke="currentColor" stroke-linejoin="round"/>
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12.1429 2.85718L5 10L12.1429 17.1429" stroke="currentColor" stroke-linecap="round"
+    stroke-linejoin="round" />
 </svg>

--- a/src/assets/icons/arrow-right.svg
+++ b/src/assets/icons/arrow-right.svg
@@ -1,3 +1,4 @@
-<svg  viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M13.5 27L22.5 18L13.5 9" stroke-linecap="round" stroke="currentColor" stroke-linejoin="round"/>
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7.14286 17.1428L14.2857 9.99997L7.14286 2.85711" stroke="currentColor" stroke-linecap="round"
+    stroke-linejoin="round" />
 </svg>

--- a/src/assets/icons/arrow-up.svg
+++ b/src/assets/icons/arrow-up.svg
@@ -1,3 +1,4 @@
-<svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M27 22.5L18 13.5L9 22.5" stroke-linecap="round" stroke="currentColor" stroke-linejoin="round"/>
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17.1429 13.5715L10 6.42868L2.85714 13.5715" stroke="currentColor" stroke-linecap="round"
+    stroke-linejoin="round" />
 </svg>

--- a/src/assets/icons/close.svg
+++ b/src/assets/icons/close.svg
@@ -1,3 +1,4 @@
-<svg viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M9.5 0.5L0.5 9.5M0.5 0.5L9.5 9.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" />
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17.1429 2.85718L2.85714 17.1429M2.85714 2.85718L17.1429 17.1429" stroke="currentColor"
+    stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/src/assets/icons/hamburger.svg
+++ b/src/assets/icons/hamburger.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M18.2047 7C18.2047 4.24299 16.1404 2 13.5889 2H6.82038C4.26888 2 2.20465 4.2352 2.20465 7H18.2047Z"
+    stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M2.20465 15C2.20465 16.6531 3.3836 18 5.93651 18H14.4728C17.0257 18 18.2047 16.6618 18.2047 15H2.20465Z"
+    stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M2.20465 10H17.7047" stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round"
+    stroke-linejoin="round" />
+  <path
+    d="M2.36603 11.698C3.63258 11.698 3.63258 12.6518 4.9078 12.6518C6.18302 12.6518 6.18302 11.698 7.44957 11.698C8.72479 11.698 8.72479 12.6518 9.99134 12.6518C11.2666 12.6518 11.2666 11.698 12.5331 11.698C13.8083 11.698 13.8083 12.6518 15.0835 12.6518C16.3588 12.6518 16.3588 11.698 17.634 11.698"
+    stroke="currentColor" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M5.0726 5.94999C5.6278 5.94999 5.6278 5.10596 5.0726 5.10596C4.5174 5.10596 4.5174 5.94999 5.0726 5.94999Z"
+    fill="currentColor" />
+  <path d="M7.3281 4.44754C7.8833 4.44754 7.8833 3.60352 7.3281 3.60352C6.76423 3.60352 6.76423 4.44754 7.3281 4.44754Z"
+    fill="currentColor" />
+  <path
+    d="M9.85253 5.8826C10.4077 5.8826 10.4077 5.03857 9.85253 5.03857C9.29733 5.03857 9.29733 5.8826 9.85253 5.8826Z"
+    fill="currentColor" />
+  <path
+    d="M12.5765 4.44754C13.1317 4.44754 13.1317 3.60352 12.5765 3.60352C12.0213 3.60352 12.0213 4.44754 12.5765 4.44754Z"
+    fill="currentColor" />
+  <path
+    d="M14.5717 5.8826C15.1269 5.8826 15.1269 5.03857 14.5717 5.03857C14.0165 5.03857 14.0078 5.8826 14.5717 5.8826Z"
+    fill="currentColor" />
+</svg>

--- a/src/components/base/Icon/IconButton.tsx
+++ b/src/components/base/Icon/IconButton.tsx
@@ -1,7 +1,7 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, HTMLAttributes } from 'react';
 import Icon, { IconProps } from '.';
 
-interface IconButtonProps extends IconProps {
+interface IconButtonProps extends IconProps, Omit<HTMLAttributes<HTMLButtonElement>, 'color'> {
   onClick?: () => void;
   type?: 'submit' | 'reset' | 'button' | undefined;
   style?: CSSProperties;

--- a/src/components/base/Icon/svg.ts
+++ b/src/components/base/Icon/svg.ts
@@ -13,3 +13,4 @@ export { default as ArrowRight } from '~/assets/icons/arrow-right.svg';
 export { default as Eye } from '~/assets/icons/eye.svg';
 export { default as Pencil } from '~/assets/icons/pencil.svg';
 export { default as Menu } from '~/assets/icons/menu.svg';
+export { default as Hamburger } from '~/assets/icons/hamburger.svg';

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -37,8 +37,7 @@ const Header = () => {
               </h1>
             </Link>
 
-            {/* 햄버거가 될 예정*/}
-            <Hambuger name="Menu" color="gray800" size="24" onClick={() => setIsOpen(true)} />
+            <Hamburger name="Hamburger" color="gray800" size="24" onClick={() => setIsOpen(true)} />
           </FirstRow>
 
           <Nav>
@@ -126,7 +125,7 @@ const CategoryList = styled.ul`
   display: flex;
 `;
 
-const Hambuger = styled(Icon.Button)`
+const Hamburger = styled(Icon.Button)`
   display: none;
 
   ${mediaQuery('sm')} {

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -2,9 +2,10 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import Icon from '~/components/base/Icon';
 
-const WINDOW_SIZE = 5;
+const VIEW_PAGE_SIZE = 5;
 const PAGE_SIZE = 20;
 const ZERO_INDEX = 1;
+
 interface PaginationProps {
   totalItem: number;
   current?: number;
@@ -28,26 +29,26 @@ const Pagination = ({
     onChange(page);
   };
 
-  const isVisiblePrevButton = () => totalPage > WINDOW_SIZE && currentPage > 0;
-  const isVisibleNextButton = () => totalPage > WINDOW_SIZE && currentPage < totalPage - 1;
-
   return (
     <Container>
-      <MoveButton onClick={() => handleChange(currentPage - 1)} isVisible={isVisiblePrevButton()}>
-        <Icon name="ArrowLeft" size="14" color="gray800" />
-      </MoveButton>
+      {totalPage > VIEW_PAGE_SIZE && (
+        <MoveButton onClick={() => handleChange(currentPage - 1)} disabled={currentPage <= 0}>
+          <span className="screen-out">이전 페이지로 이동</span>
+          <Icon name="ArrowLeft" size="14" color="gray800" />
+        </MoveButton>
+      )}
 
       {Array.from(new Array(totalPage), (_, index) => index)
         .filter((index) => {
-          const windowCenter = Math.ceil(WINDOW_SIZE / 2);
-          const windowHalf = Math.floor(WINDOW_SIZE / 2);
+          const centerOffset = Math.ceil(VIEW_PAGE_SIZE / 2);
+          const halfOffset = Math.floor(VIEW_PAGE_SIZE / 2);
 
-          if (currentPage < windowCenter) {
-            return index < WINDOW_SIZE;
-          } else if (currentPage > totalPage - windowCenter) {
-            return index >= totalPage - WINDOW_SIZE;
+          if (currentPage < centerOffset) {
+            return index < VIEW_PAGE_SIZE;
+          } else if (currentPage > totalPage - centerOffset) {
+            return index >= totalPage - VIEW_PAGE_SIZE;
           }
-          return index >= currentPage - windowHalf && index <= currentPage + windowHalf;
+          return index >= currentPage - halfOffset && index <= currentPage + halfOffset;
         })
         .map((page) => (
           <PageButton
@@ -59,9 +60,15 @@ const Pagination = ({
           </PageButton>
         ))}
 
-      <MoveButton onClick={() => handleChange(currentPage + 1)} isVisible={isVisibleNextButton()}>
-        <Icon name="ArrowRight" size="14" color="gray800" />
-      </MoveButton>
+      {totalPage > VIEW_PAGE_SIZE && (
+        <MoveButton
+          onClick={() => handleChange(currentPage + 1)}
+          disabled={currentPage >= totalPage - 1}
+        >
+          <span className="screen-out">다음 페이지로 이동</span>
+          <Icon name="ArrowRight" size="14" color="gray800" />
+        </MoveButton>
+      )}
     </Container>
   );
 };
@@ -74,13 +81,11 @@ const Container = styled.div`
   align-items: center;
 `;
 
-const MoveButton = styled.button<{ isVisible: boolean }>`
+const MoveButton = styled.button`
   width: 33px;
   height: 33px;
   border: 1px solid ${({ theme }) => theme.colors.gray300};
   border-radius: 4px;
-  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
-  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
 
   svg {
     margin: 0 auto;
@@ -92,6 +97,12 @@ const MoveButton = styled.button<{ isVisible: boolean }>`
 
   &:last-of-type {
     margin-left: 10px;
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    background-color: ${({ theme }) => theme.colors.gray100};
+    cursor: not-allowed;
   }
 `;
 

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -1,0 +1,114 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import Icon from '~/components/base/Icon';
+
+const WINDOW_SIZE = 5;
+const PAGE_SIZE = 20;
+const ZERO_INDEX = 1;
+interface PaginationProps {
+  totalItem: number;
+  current?: number;
+  pageSize?: number;
+  onChange: (page: number) => void;
+}
+
+const Pagination = ({
+  totalItem,
+  current = 0,
+  pageSize = PAGE_SIZE,
+  onChange,
+}: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(current);
+  const totalPage = Math.ceil(totalItem / pageSize);
+
+  const handleChange = (page: number) => {
+    if (page === currentPage) return;
+
+    setCurrentPage(page);
+    onChange(page);
+  };
+
+  const isVisiblePrevButton = () => totalPage > WINDOW_SIZE && currentPage > 0;
+  const isVisibleNextButton = () => totalPage > WINDOW_SIZE && currentPage < totalPage - 1;
+
+  return (
+    <Container>
+      <MoveButton onClick={() => handleChange(currentPage - 1)} isVisible={isVisiblePrevButton()}>
+        <Icon name="ArrowLeft" size="14" color="gray800" />
+      </MoveButton>
+
+      {Array.from(new Array(totalPage), (_, index) => index)
+        .filter((index) => {
+          const windowCenter = Math.ceil(WINDOW_SIZE / 2);
+          const windowHalf = Math.floor(WINDOW_SIZE / 2);
+
+          if (currentPage < windowCenter) {
+            return index < WINDOW_SIZE;
+          } else if (currentPage > totalPage - windowCenter) {
+            return index >= totalPage - WINDOW_SIZE;
+          }
+          return index >= currentPage - windowHalf && index <= currentPage + windowHalf;
+        })
+        .map((page) => (
+          <PageButton
+            key={page}
+            onClick={() => handleChange(page)}
+            className={currentPage === page ? 'is-active' : undefined}
+          >
+            {ZERO_INDEX + page}
+          </PageButton>
+        ))}
+
+      <MoveButton onClick={() => handleChange(currentPage + 1)} isVisible={isVisibleNextButton()}>
+        <Icon name="ArrowRight" size="14" color="gray800" />
+      </MoveButton>
+    </Container>
+  );
+};
+
+export default Pagination;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const MoveButton = styled.button<{ isVisible: boolean }>`
+  width: 33px;
+  height: 33px;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 4px;
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+
+  svg {
+    margin: 0 auto;
+  }
+
+  &:first-of-type {
+    margin-right: 10px;
+  }
+
+  &:last-of-type {
+    margin-left: 10px;
+  }
+`;
+
+const PageButton = styled.button`
+  width: 26px;
+  height: 26px;
+  border: 0;
+  ${({ theme }) => theme.fontStyle.body2}
+  text-align: center;
+  color: ${({ theme }) => theme.colors.gray800};
+  user-select: none;
+
+  &.is-active {
+    color: ${({ theme }) => theme.colors.red};
+  }
+
+  & ~ & {
+    margin-left: 5px;
+  }
+`;

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -1,0 +1,28 @@
+import Pagination from '~/components/common/Pagination';
+
+const Test = () => {
+  const pageSize = 20;
+
+  return (
+    <>
+      <Pagination
+        totalItem={pageSize * 1}
+        pageSize={20}
+        onChange={(page: number) => console.log(page)}
+      />
+      <Pagination
+        totalItem={pageSize * 4}
+        pageSize={20}
+        onChange={(page: number) => console.log(page)}
+      />
+      <Pagination
+        totalItem={pageSize * 11}
+        pageSize={20}
+        onChange={(page: number) => console.log(page)}
+        current={5}
+      />
+    </>
+  );
+};
+
+export default Test;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,3 +38,12 @@ h2,
 h3 {
   font-family: Pretendard;
 }
+
+.screen-out {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  line-height: 0;
+  text-indent: -9999px;
+}


### PR DESCRIPTION
close #81 

## ✅ 작업 내용
- Pagination 컴포넌트 구현

  |props|type|description|
  |-|-|-|
  |totalItem|number?|총 아이템 개수 <br /> (API 명세서에 따라 변경될 예정)|
  |current|number?|현재 페이지|
  |pageSize|number?|한 페이지 당 아이템 개수|
  |onChange|(page: number) => void|현재 페이지가 변할 때 실행되는 핸들러|

- /test 페이지에 Pagination 컴포넌트 배치

## ✍ 궁금한 점
- `totalItem` 변수명 너무 구린데..괜찮나요?
- 이전/다음 버튼 못 누를 때, 막상 안 보이니 어색한 거 같기도 한데 어떻게 생각하시나요😅