### PR TITLE
Feat/#85 ProfileDropdown 컴포넌트 구현

### DIFF
--- a/src/components/common/Header/ProfileDropdown.tsx
+++ b/src/components/common/Header/ProfileDropdown.tsx
@@ -1,0 +1,164 @@
+import styled from '@emotion/styled';
+import { MouseEvent, SyntheticEvent, useState } from 'react';
+import Link from '~/components/base/Link';
+import useClickAway from '~/hooks/useClickAway';
+
+interface ProfileDropdownProps {
+  user: {
+    // IUser로 변경
+    name: string;
+    profileUrl: string;
+  };
+}
+
+const ProfileDropdown = ({ user: { name, profileUrl } }: ProfileDropdownProps) => {
+  const [open, setOpen] = useState(false);
+  const ref = useClickAway<HTMLDetailsElement>(() => {
+    if (open) handleClick();
+  });
+
+  const handleClick = () => setOpen(!open);
+
+  const handleToggle = (e: MouseEvent<HTMLImageElement>) => {
+    e.preventDefault();
+    handleClick();
+  };
+
+  const handleLogout = () => {
+    handleClick();
+    // 로그아웃
+  };
+
+  const handleImageError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+    e.currentTarget.src =
+      'https://user-images.githubusercontent.com/96400112/199486983-984a02a3-3835-40fc-91a2-c1ca7e17e7a2.png';
+  };
+
+  return (
+    <StyledDetails open={open} ref={ref}>
+      <StyledSummary>
+        <ProfileImage>
+          <span className="screen-out">프로필 메뉴 열기</span>
+          <img
+            src={profileUrl}
+            alt="프로필 이미지"
+            width={46}
+            height={46}
+            onClick={handleToggle}
+            onError={handleImageError}
+          />
+        </ProfileImage>
+      </StyledSummary>
+
+      <Content>
+        <UsernameContainer>
+          <Username>{name} 님</Username>
+        </UsernameContainer>
+
+        <StyledUl>
+          <StyledLi>
+            <Link href="/question/create" onClick={handleClick}>
+              질문 등록
+            </Link>
+          </StyledLi>
+          <StyledLi>
+            <Link href="/my" onClick={handleClick}>
+              마이페이지
+            </Link>
+          </StyledLi>
+          <StyledLi>
+            <Link href="/" onClick={handleLogout}>
+              로그아웃
+            </Link>
+          </StyledLi>
+        </StyledUl>
+      </Content>
+    </StyledDetails>
+  );
+};
+
+export default ProfileDropdown;
+
+const StyledDetails = styled.details`
+  position: relative;
+`;
+
+const StyledSummary = styled.summary`
+  list-style: none;
+  cursor: pointer;
+
+  &::webkit-details-marker {
+    display: none;
+  }
+`;
+
+const ProfileImage = styled.div`
+  height: 46px;
+
+  img {
+    border-radius: 50%;
+    border: 1px solid ${({ theme }) => theme.colors.gray300};
+    object-fit: cover;
+  }
+`;
+
+const Content = styled.div`
+  position: absolute;
+  top: 56px;
+  left: -22px;
+  min-width: 139px;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.colors.white};
+  box-shadow: 0px 1px 2px rgba(204, 204, 204, 0.25);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: -8px;
+    left: 40px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 7px solid ${({ theme }) => theme.colors.gray300};
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: -7px;
+    left: 41px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-bottom: 7px solid ${({ theme }) => theme.colors.white};
+  }
+`;
+
+const UsernameContainer = styled.div`
+  padding: 12px 16px 8px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+`;
+
+const Username = styled.span`
+  ${({ theme }) => theme.fontStyle.body2}
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.gray800};
+  user-select: none;
+`;
+
+const StyledUl = styled.ul`
+  padding: 16px 0;
+
+  li ~ li {
+    margin-top: 8px;
+  }
+`;
+
+const StyledLi = styled.li`
+  ${({ theme }) => theme.fontStyle.body2}
+
+  a {
+    display: block;
+    padding: 0 16px;
+    color: ${({ theme }) => theme.colors.gray700};
+  }
+`;

--- a/src/components/common/Header/Slide.tsx
+++ b/src/components/common/Header/Slide.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
+import { MouseEvent, useEffect } from 'react';
 import BackgroundDim from '~/components/base/BackgroundDim';
 import Link from '~/components/base/Link';
-import useClickAway from '~/hooks/useClickAway';
 import { ThemeColors } from '~/types/theme';
+import { mediaQuery } from '~/utils/helper/mediaQuery';
 import CloseButton from '../CloseButton';
 
 interface SlideProps {
@@ -12,7 +12,9 @@ interface SlideProps {
 }
 
 const Slide = ({ isOpen, onClose }: SlideProps) => {
-  const contentRef = useClickAway<HTMLDivElement>(onClose);
+  const handleClose = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
 
   useEffect(() => {
     if (isOpen) {
@@ -23,8 +25,8 @@ const Slide = ({ isOpen, onClose }: SlideProps) => {
   }, [isOpen]);
 
   return (
-    <StyledBackgroundDim isOpen={isOpen}>
-      <SlideContent isOpen={isOpen} ref={contentRef}>
+    <StyledBackgroundDim isOpen={isOpen} onClick={handleClose}>
+      <SlideContent isOpen={isOpen}>
         <StyledCloseButton onClick={onClose} />
 
         <nav>
@@ -64,7 +66,7 @@ const StyledBackgroundDim = styled(BackgroundDim)<{ isOpen: boolean }>`
 `;
 
 const SlideContent = styled.div<{ isOpen: boolean }>`
-  position: relative;
+  position: absolute;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -11,6 +11,7 @@ import Slide from './Slide';
 import useStorage from '~/hooks/useStorage';
 import { LOCAL_KEY } from '~/utils/constant/user';
 import { UserContext } from '~/context/user';
+import ProfileDropdown from './ProfileDropdown';
 
 const Header = () => {
   const router = useRouter();
@@ -70,17 +71,17 @@ const Header = () => {
 
         <RightArea>
           {/* id로 비교할 예정 */}
-          {!currentUser.token && (
+          {!currentUser.token ? (
             <Link size="sm" linkType="borderGray" href="/login">
               로그인
             </Link>
+          ) : (
+            // currentUser로 변경
+            <ProfileDropdown user={{ name: 'jini', profileUrl: 'https://picsum.photos/200/600' }} />
           )}
 
           <Link size="sm" linkType="red" href="/random/create?step=0" as="/random/create">
             랜덤 질문
-          </Link>
-          <Link size="sm" linkType="black" href="/question/create">
-            질문 등록
           </Link>
         </RightArea>
       </HeaderContent>
@@ -153,8 +154,12 @@ const Hamburger = styled(Icon.Button)`
 `;
 
 const RightArea = styled.div`
-  a ~ a {
-    margin-left: 15px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  a:last-of-type {
+    margin-left: 14px;
   }
 
   ${mediaQuery('sm')} {


### PR DESCRIPTION
close #85 

## ✅ 작업 내용
- `ProfileDropdown` 컴포넌트 구현
- `Header` 컴포넌트에 `ProfileDropdown` 컴포넌트 추가
- `Slide` 컴포넌트에서 `useClickAway` 제거
  - 다른 요소에서 `useClickAway` 사용할 때, z-index가 높은 `Slide` 컴포넌트에서 클릭 이벤트가 발생해서 제대로 동작하지 않는 문제

## ✍ 궁금한 점
<img src='https://user-images.githubusercontent.com/96400112/199492054-d1534489-cc14-45c3-b2b1-d634fa2b8e69.png' 
width="40%" />
- 저 툴팁 삼각형 아래 border 없앨 수 있는데 없앨까요? 그대로 갈까요?
- 스타일 수정할 거 있으면 알려주세요👀
- 헤더에서 질문등록 제거할까요?
- Image 컴포넌트로 분리할까요?