### PR TITLE
Feat/#90 로그인 유지, 로그아웃 기능 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/user',
+        destination: 'https://ak-47.shop/api/v1/user',
+      },
+    ];
+  },
   swcMinify: true,
   webpack(config) {
     config.module.rules.push({
@@ -18,6 +26,11 @@ const nextConfig = {
     EMAILJS_PUBLIC_KEY: process.env.EMAILJS_PUBLIC_KEY,
     GTM_ID: process.env.GTM_ID,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  },
+  images: {
+    // google 기본 프로필 이미지 가져올 때 사용
+    domains: ['lh3.googleusercontent.com'],
+    formats: ['image/avif', 'image/webp'],
   },
 };
 

--- a/src/components/common/Avatar/index.tsx
+++ b/src/components/common/Avatar/index.tsx
@@ -1,15 +1,24 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
+import { MouseEvent, SyntheticEvent, useState } from 'react';
 import { AvatarSize, AvatarSizes } from './types';
 
 interface AvatarProps {
-  imageUrl?: string;
+  src?: string;
   size?: AvatarSizes;
   alt?: string;
+  onClick?: (e: MouseEvent<HTMLImageElement>) => void;
 }
 
-const Avatar = ({ imageUrl, size = 'md', alt = '프로필이미지', ...props }: AvatarProps) => {
-  const defaultImage = '/assets/profile-default.jpeg';
+const defaultImage = '/assets/profile-default.jpeg';
+
+const Avatar = ({ src, size = 'md', alt = '프로필이미지', ...props }: AvatarProps) => {
+  const [imageUrl, setImageUrl] = useState(src || defaultImage);
+
+  const handleImageError = () => {
+    setImageUrl(defaultImage);
+  };
+
   return (
     <Container size={size} {...props}>
       <Image
@@ -18,6 +27,7 @@ const Avatar = ({ imageUrl, size = 'md', alt = '프로필이미지', ...props }:
         objectPosition="center"
         src={imageUrl || defaultImage}
         alt={alt}
+        onError={handleImageError}
       />
     </Container>
   );

--- a/src/components/common/Avatar/index.tsx
+++ b/src/components/common/Avatar/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { MouseEvent, SyntheticEvent, useState } from 'react';
+import { MouseEvent, SyntheticEvent, useEffect, useState } from 'react';
 import { AvatarSize, AvatarSizes } from './types';
 
 interface AvatarProps {
@@ -13,10 +13,10 @@ interface AvatarProps {
 const defaultImage = '/assets/profile-default.jpeg';
 
 const Avatar = ({ src, size = 'md', alt = '프로필이미지', ...props }: AvatarProps) => {
-  const [imageUrl, setImageUrl] = useState(src || defaultImage);
+  const imageUrl = src || defaultImage;
 
-  const handleImageError = () => {
-    setImageUrl(defaultImage);
+  const handleImageError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+    e.currentTarget.src = defaultImage;
   };
 
   return (

--- a/src/components/common/CloseButton/index.tsx
+++ b/src/components/common/CloseButton/index.tsx
@@ -6,7 +6,7 @@ interface CloseButtonProps {
 }
 
 const CloseButton = ({ onClick, ...props }: CloseButtonProps) => {
-  return <StyledButton name="Close" color="gray800" size="14" onClick={onClick} {...props} />;
+  return <StyledButton name="Close" color="gray800" size="20" onClick={onClick} {...props} />;
 };
 
 export default CloseButton;

--- a/src/components/common/Header/ProfileDropdown.tsx
+++ b/src/components/common/Header/ProfileDropdown.tsx
@@ -1,17 +1,17 @@
 import styled from '@emotion/styled';
-import { MouseEvent, SyntheticEvent, useState } from 'react';
+import { MouseEvent, useContext, useState } from 'react';
 import Link from '~/components/base/Link';
+import { UserContext } from '~/context/user';
 import useClickAway from '~/hooks/useClickAway';
+import { IUser } from '~/types/user';
+import Avatar from '../Avatar';
 
 interface ProfileDropdownProps {
-  user: {
-    // IUser로 변경
-    name: string;
-    profileUrl: string;
-  };
+  user: IUser;
 }
 
-const ProfileDropdown = ({ user: { name, profileUrl } }: ProfileDropdownProps) => {
+const ProfileDropdown = ({ user: { username, profileUrl } }: ProfileDropdownProps) => {
+  const { logout } = useContext(UserContext);
   const [open, setOpen] = useState(false);
   const ref = useClickAway<HTMLDetailsElement>(() => {
     if (open) handleClick();
@@ -26,12 +26,7 @@ const ProfileDropdown = ({ user: { name, profileUrl } }: ProfileDropdownProps) =
 
   const handleLogout = () => {
     handleClick();
-    // 로그아웃
-  };
-
-  const handleImageError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
-    e.currentTarget.src =
-      'https://user-images.githubusercontent.com/96400112/199486983-984a02a3-3835-40fc-91a2-c1ca7e17e7a2.png';
+    logout();
   };
 
   return (
@@ -39,20 +34,13 @@ const ProfileDropdown = ({ user: { name, profileUrl } }: ProfileDropdownProps) =
       <StyledSummary>
         <ProfileImage>
           <span className="screen-out">프로필 메뉴 열기</span>
-          <img
-            src={profileUrl}
-            alt="프로필 이미지"
-            width={46}
-            height={46}
-            onClick={handleToggle}
-            onError={handleImageError}
-          />
+          <Avatar src={profileUrl} size="md" onClick={handleToggle} />
         </ProfileImage>
       </StyledSummary>
 
       <Content>
         <UsernameContainer>
-          <Username>{name} 님</Username>
+          <Username>{username} 님</Username>
         </UsernameContainer>
 
         <StyledUl>
@@ -94,12 +82,6 @@ const StyledSummary = styled.summary`
 
 const ProfileImage = styled.div`
   height: 46px;
-
-  img {
-    border-radius: 50%;
-    border: 1px solid ${({ theme }) => theme.colors.gray300};
-    object-fit: cover;
-  }
 `;
 
 const Content = styled.div`

--- a/src/components/common/Header/Slide.tsx
+++ b/src/components/common/Header/Slide.tsx
@@ -1,17 +1,22 @@
 import styled from '@emotion/styled';
 import { MouseEvent, useEffect } from 'react';
 import BackgroundDim from '~/components/base/BackgroundDim';
+import Button from '~/components/base/Button';
 import Link from '~/components/base/Link';
 import { ThemeColors } from '~/types/theme';
+import { IUser } from '~/types/user';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
 import CloseButton from '../CloseButton';
+import Logo from '../Logo';
+import UserProfile from '../UserProfile';
 
 interface SlideProps {
+  user: IUser;
   isOpen: boolean;
   onClose: () => void;
 }
 
-const Slide = ({ isOpen, onClose }: SlideProps) => {
+const Slide = ({ user, isOpen, onClose }: SlideProps) => {
   const handleClose = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) onClose();
   };
@@ -26,33 +31,50 @@ const Slide = ({ isOpen, onClose }: SlideProps) => {
 
   return (
     <StyledBackgroundDim isOpen={isOpen} onClick={handleClose}>
-      <SlideContent isOpen={isOpen}>
-        <StyledCloseButton onClick={onClose} />
+      <SlideContainer isOpen={isOpen}>
+        <SlideHeader>
+          <Link href="/" onClick={onClose}>
+            <Logo size="sm" />
+          </Link>
+          <StyledCloseButton onClick={onClose} />
+        </SlideHeader>
+        <SlideContent>
+          <nav>
+            <UserArea>
+              {user.id ? (
+                <Link href={`/profile/${user.id}`}>
+                  <UserProfile profileUrl={user.profileUrl} text={user.username} />
+                </Link>
+              ) : (
+                <LoginButton linkType="red" size="md" href="/login" onClick={onClose}>
+                  로그인
+                </LoginButton>
+              )}
+            </UserArea>
+            <StyledUl>
+              <li>
+                <StyledLink
+                  href="/random/create?step=0"
+                  as="/random/create"
+                  onClick={onClose}
+                  color="red"
+                >
+                  랜덤질문
+                </StyledLink>
+              </li>
+              <li>
+                <StyledLink href="/question/create" onClick={onClose} color="gray800">
+                  질문등록
+                </StyledLink>
+              </li>
+            </StyledUl>
+          </nav>
 
-        <nav>
-          <StyledUl>
-            <li>
-              <StyledLink
-                href="/random/create?step=0"
-                as="/random/create"
-                onClick={onClose}
-                color="red"
-              >
-                랜덤질문
-              </StyledLink>
-            </li>
-            <li>
-              <StyledLink href="/question/create" onClick={onClose} color="gray800">
-                질문등록
-              </StyledLink>
-            </li>
-          </StyledUl>
-        </nav>
-
-        <StyledLink href="/suggestion" onClick={onClose} color="gray800">
-          건의하기
-        </StyledLink>
-      </SlideContent>
+          <StyledLink href="/suggestion" onClick={onClose} color="gray800">
+            건의하기
+          </StyledLink>
+        </SlideContent>
+      </SlideContainer>
     </StyledBackgroundDim>
   );
 };
@@ -65,27 +87,56 @@ const StyledBackgroundDim = styled(BackgroundDim)<{ isOpen: boolean }>`
   transition: all 0.3s ease-in-out;
 `;
 
-const SlideContent = styled.div<{ isOpen: boolean }>`
+const SlideContainer = styled.div<{ isOpen: boolean }>`
   position: absolute;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
   width: 300px;
   height: 100%;
   border: 1px solid ${({ theme }) => theme.colors.gray300};
-  padding: 60px 21px 42px;
+
+  display: flex;
+  flex-direction: column;
+
   background-color: ${({ theme }) => theme.colors.white};
   transform: ${({ isOpen }) => (isOpen ? 'translate3d(0, 0, 0)' : 'translate3d(-70%, 0, 0)')};
   transition: all 0.3s ease-in-out;
 `;
 
+const SlideHeader = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 50px;
+  padding: 0 20px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+`;
+
+const SlideContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0 20px 42px;
+  flex-grow: 1;
+`;
+
+const UserArea = styled.div`
+  padding: 20px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+`;
+
+const LoginButton = styled(Link)`
+  width: 100%;
+  text-align: center;
+`;
+
 const StyledCloseButton = styled(CloseButton)`
   position: absolute;
-  top: 25px;
-  right: 21px;
+  top: 10px;
+  right: 16px;
 `;
 
 const StyledUl = styled.ul`
+  margin-top: 30px;
   li ~ li {
     margin-top: 14px;
   }

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -19,6 +19,28 @@ const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
   const storage = useStorage('local');
   const { currentUser, logout, updateUser } = useContext(UserContext);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const getUserProfile = async () => {
+    setIsLoading(true);
+    const token = storage.getItem(LOCAL_KEY.token, '');
+
+    // 로컬에서 토큰 변경 및 삭제 시
+    if (currentUser.token && !token && token !== currentUser.token) {
+      logout();
+    }
+
+    // 새로고침하여 userState 초기화 시
+    if (token && token !== currentUser.token) {
+      await updateUser(token);
+    }
+
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    getUserProfile();
+  }, []);
 
   useEffect(() => {
     if (!router.isReady) {
@@ -31,20 +53,6 @@ const Header = () => {
       setSelectedCategory('');
     }
   }, [router.isReady, router.query]);
-
-  useEffect(() => {
-    const token = storage.getItem(LOCAL_KEY.token, '');
-
-    // 로컬에서 토큰 변경 및 삭제 시
-    if (currentUser.token && !token && token !== currentUser.token) {
-      logout();
-    }
-
-    // 새로고침하여 userState 초기화 시
-    if (token && token !== currentUser.token) {
-      updateUser(token);
-    }
-  }, []);
 
   return (
     <StyledHeader>
@@ -77,7 +85,7 @@ const Header = () => {
         </LeftArea>
 
         <RightArea>
-          {!currentUser.token ? (
+          {!currentUser.token && !isLoading ? (
             <Link size="sm" linkType="borderGray" href="/login">
               로그인
             </Link>

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -4,13 +4,13 @@ import { useContext, useEffect, useState } from 'react';
 import Link from '~/components/base/Link';
 import PageContainer from '~/components/common/PageContainer';
 import Logo from '../Logo';
-import CategoryListItem from './CategoryListItem';
 import Icon from '~/components/base/Icon/index';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
-import Slide from './Slide';
 import useStorage from '~/hooks/useStorage';
 import { LOCAL_KEY } from '~/utils/constant/user';
 import { UserContext } from '~/context/user';
+import Slide from './Slide';
+import CategoryListItem from './CategoryListItem';
 import ProfileDropdown from './ProfileDropdown';
 
 const Header = () => {
@@ -18,7 +18,7 @@ const Header = () => {
   const [selectedCategory, setSelectedCategory] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const storage = useStorage('local');
-  const { currentUser } = useContext(UserContext);
+  const { currentUser, logout, updateUser } = useContext(UserContext);
 
   useEffect(() => {
     if (!router.isReady) {
@@ -34,8 +34,15 @@ const Header = () => {
 
   useEffect(() => {
     const token = storage.getItem(LOCAL_KEY.token, '');
+
+    // 로컬에서 토큰 변경 및 삭제 시
+    if (currentUser.token && !token && token !== currentUser.token) {
+      logout();
+    }
+
+    // 새로고침하여 userState 초기화 시
     if (token && token !== currentUser.token) {
-      /* 토큰으로 유저 정보 재발급 코드 작성 */
+      updateUser(token);
     }
   }, []);
 
@@ -70,14 +77,12 @@ const Header = () => {
         </LeftArea>
 
         <RightArea>
-          {/* id로 비교할 예정 */}
           {!currentUser.token ? (
             <Link size="sm" linkType="borderGray" href="/login">
               로그인
             </Link>
           ) : (
-            // currentUser로 변경
-            <ProfileDropdown user={{ name: 'jini', profileUrl: 'https://picsum.photos/200/600' }} />
+            <ProfileDropdown user={currentUser.user} />
           )}
 
           <Link size="sm" linkType="red" href="/random/create?step=0" as="/random/create">
@@ -158,7 +163,7 @@ const RightArea = styled.div`
   justify-content: center;
   align-items: center;
 
-  a:last-of-type {
+  & > a:last-of-type {
     margin-left: 14px;
   }
 

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -17,9 +17,9 @@ const Header = () => {
   const router = useRouter();
   const [selectedCategory, setSelectedCategory] = useState('');
   const [isOpen, setIsOpen] = useState(false);
-  const storage = useStorage('local');
-  const { currentUser, logout, updateUser } = useContext(UserContext);
   const [isLoading, setIsLoading] = useState(true);
+  const { currentUser, logout, updateUser } = useContext(UserContext);
+  const storage = useStorage('local');
 
   const getUserProfile = async () => {
     setIsLoading(true);
@@ -99,7 +99,7 @@ const Header = () => {
         </RightArea>
       </HeaderContent>
 
-      <Slide isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <Slide user={currentUser.user} isOpen={isOpen} onClose={() => setIsOpen(false)} />
     </StyledHeader>
   );
 };

--- a/src/components/common/Logo/index.tsx
+++ b/src/components/common/Logo/index.tsx
@@ -4,12 +4,40 @@ import LogoText from '~/assets/images/logo-text.svg';
 
 interface LogoProps {
   type?: 'normal' | 'text';
+  size?: 'sm' | 'md';
 }
 
-const Logo = ({ type = 'normal' }: LogoProps) => {
+const logoSize = {
+  normal: {
+    sm: {
+      width: 143,
+      height: 25,
+    },
+    md: {
+      width: 185,
+      height: 32,
+    },
+  },
+  text: {
+    sm: {
+      width: 130,
+      height: 20,
+    },
+    md: {
+      width: 175,
+      height: 28,
+    },
+  },
+};
+
+const Logo = ({ type = 'normal', size = 'md' }: LogoProps) => {
   return (
     <LogoWrapper>
-      {type === 'text' ? <LogoText width={175} height={28} /> : <LogoSvg width={185} height={32} />}
+      {type === 'text' ? (
+        <LogoText width={logoSize.text[size].width} height={logoSize.text[size].height} />
+      ) : (
+        <LogoSvg width={logoSize.normal[size].width} height={logoSize.normal[size].height} />
+      )}
     </LogoWrapper>
   );
 };

--- a/src/components/common/UserProfile/index.tsx
+++ b/src/components/common/UserProfile/index.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import { theme } from '~/types/theme';
+import Avatar from '../Avatar';
+
+interface UserProfileProps {
+  profileUrl?: string;
+  avatarSize?: 'md' | 'sm';
+  fontSize?: 'sm' | 'md' | 'lg';
+  text: string;
+}
+
+const UserProfile = ({
+  profileUrl,
+  avatarSize = 'md',
+  fontSize = 'md',
+  text,
+}: UserProfileProps) => {
+  return (
+    <Container>
+      <Avatar src={profileUrl} size={avatarSize} />
+      <Text fontSize={fontSize}>{text}</Text>
+    </Container>
+  );
+};
+
+const textSize = {
+  sm: `
+    margin-left: 4px;
+    ${theme.fontStyle.body1}
+`,
+  md: `
+    margin-left: 10px;
+    ${theme.fontStyle.subtitle1}
+  `,
+
+  lg: `
+    margin-left: 12px;
+    ${theme.fontStyle.subtitle1}
+  `,
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Text = styled.span<{ fontSize: 'sm' | 'md' | 'lg' }>`
+  ${({ fontSize }) => fontSize && textSize[fontSize]};
+`;
+
+export default UserProfile;

--- a/src/components/domain/profile/EditAvatar.tsx
+++ b/src/components/domain/profile/EditAvatar.tsx
@@ -6,7 +6,7 @@ import { mediaQuery } from '~/utils/helper/mediaQuery';
 interface EditAvatarProps {
   imageUrl?: string;
   size?: AvatarSizes;
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 const EditAvatar = ({ imageUrl, size, onClick }: EditAvatarProps) => {
@@ -15,7 +15,7 @@ const EditAvatar = ({ imageUrl, size, onClick }: EditAvatarProps) => {
       <div className="background">
         <span>프로필 수정</span>
       </div>
-      <Avatar imageUrl={imageUrl} size={size} />
+      <Avatar src={imageUrl} size={size} />
     </Container>
   );
 };

--- a/src/context/user.tsx
+++ b/src/context/user.tsx
@@ -1,42 +1,77 @@
 import { createContext, ReactNode, useCallback, useState } from 'react';
+import useStorage from '~/hooks/useStorage';
+import { getUerInfo } from '~/service/user';
+import { ICurrentUser } from '~/types/user';
+import { LOCAL_KEY } from '~/utils/constant/user';
 
-// id필요
 // refresh token
 // userEmail/userName -> email/username로 변경 예정
 
 const initialValue = {
   token: '',
   user: {
+    id: null,
     username: '',
     email: '',
+    profileUrl: '',
   },
 };
 
-interface IUser {
-  username: string;
-  email: string;
-}
-interface ICurrentUser {
+interface Token {
   token: string;
-  user: IUser;
+  refreshToken: string;
 }
 
 interface UserContextTypes {
   currentUser: ICurrentUser;
-  updateUser: (userData: ICurrentUser) => void;
+  logout: () => void;
+  updateUser: (token: string) => void;
+  setToken: ({ token, refreshToken }: Token) => void;
 }
 
 export const UserContext = createContext<UserContextTypes>({} as UserContextTypes);
 
 const UserProvider = ({ children }: { children: ReactNode }) => {
   const [currentUser, setCurrentUser] = useState(initialValue);
+  const storage = useStorage('local');
 
-  const updateUser = useCallback((userData: ICurrentUser) => {
-    setCurrentUser(userData);
+  const setToken = useCallback(({ token, refreshToken }: Token) => {
+    storage.setItem(LOCAL_KEY.token, token);
+    storage.setItem(LOCAL_KEY.refresh, refreshToken);
+  }, []);
+
+  const updateUser = useCallback(async (token: string) => {
+    try {
+      const { data } = await getUerInfo(token);
+      if (!data) {
+        logout();
+        return;
+      }
+
+      setCurrentUser({
+        token,
+        user: {
+          id: data.id,
+          username: data.username || data.name,
+          email: data.email,
+          profileUrl: data.profileUrl,
+        },
+      });
+    } catch {
+      logout();
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    setCurrentUser(initialValue);
+    storage.removeItem(LOCAL_KEY.token);
+    storage.removeItem(LOCAL_KEY.refresh);
   }, []);
 
   return (
-    <UserContext.Provider value={{ currentUser, updateUser }}>{children}</UserContext.Provider>
+    <UserContext.Provider value={{ currentUser, updateUser, logout, setToken }}>
+      {children}
+    </UserContext.Provider>
   );
 };
 

--- a/src/context/user.tsx
+++ b/src/context/user.tsx
@@ -26,7 +26,7 @@ interface UserContextTypes {
   currentUser: ICurrentUser;
   logout: () => void;
   updateUser: (token: string) => void;
-  setToken: ({ token, refreshToken }: Token) => void;
+  login: ({ token, refreshToken }: Token) => void;
 }
 
 export const UserContext = createContext<UserContextTypes>({} as UserContextTypes);
@@ -35,9 +35,10 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
   const [currentUser, setCurrentUser] = useState(initialValue);
   const storage = useStorage('local');
 
-  const setToken = useCallback(({ token, refreshToken }: Token) => {
+  const login = useCallback(({ token, refreshToken }: Token) => {
     storage.setItem(LOCAL_KEY.token, token);
     storage.setItem(LOCAL_KEY.refresh, refreshToken);
+    updateUser(token);
   }, []);
 
   const updateUser = useCallback(async (token: string) => {
@@ -69,7 +70,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   return (
-    <UserContext.Provider value={{ currentUser, updateUser, logout, setToken }}>
+    <UserContext.Provider value={{ currentUser, updateUser, logout, login }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/context/user.tsx
+++ b/src/context/user.tsx
@@ -25,7 +25,7 @@ interface Token {
 interface UserContextTypes {
   currentUser: ICurrentUser;
   logout: () => void;
-  updateUser: (token: string) => void;
+  updateUser: (token: string) => Promise<void>;
   login: ({ token, refreshToken }: Token) => void;
 }
 
@@ -33,6 +33,7 @@ export const UserContext = createContext<UserContextTypes>({} as UserContextType
 
 const UserProvider = ({ children }: { children: ReactNode }) => {
   const [currentUser, setCurrentUser] = useState(initialValue);
+
   const storage = useStorage('local');
 
   const login = useCallback(({ token, refreshToken }: Token) => {
@@ -44,6 +45,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
   const updateUser = useCallback(async (token: string) => {
     try {
       const { data } = await getUerInfo(token);
+
       if (!data) {
         logout();
         return;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -13,12 +13,12 @@ import { UserContext } from '~/context/user';
 const Login = () => {
   const router = useRouter();
   const [googleUrl, setGoogleUrl] = useState('');
-  const { setToken } = useContext(UserContext);
+  const { login } = useContext(UserContext);
 
   const requestLogin = async (code: string) => {
     try {
       const res = await googleLogin({ code, redirectUrl: `${window.location.origin}/login` });
-      setToken({ token: res.data.jwtToken, refreshToken: res.data.refreshToken });
+      login({ token: res.data.jwtToken, refreshToken: res.data.refreshToken });
       router.push('/');
     } catch (e) {
       alert('로그인에 실패했습니다.');

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -33,6 +33,12 @@ const Login = () => {
     setGoogleUrl(res.data);
   };
 
+  const onClickGoogleLogin = () => {
+    if (googleUrl.length === 0) {
+      alert('로그인 연결에 실패했습니다.');
+    }
+  };
+
   useEffect(() => {
     requestGoogleLink();
   }, []);
@@ -53,7 +59,7 @@ const Login = () => {
         <Icon name="LogoIcon" size="110" />
       </LogoArea>
       <SocialButtons>
-        <SocialLink linkType="borderGray" size="lg" href={googleUrl}>
+        <SocialLink linkType="borderGray" size="lg" href={googleUrl} onClick={onClickGoogleLogin}>
           <Icon name="Google" />
           <span>구글 계정으로 계속하기</span>
         </SocialLink>

--- a/src/service/oauth.ts
+++ b/src/service/oauth.ts
@@ -12,3 +12,7 @@ interface LoginResponse {
 export const googleLogin = ({ code, redirectUrl }: { code: string; redirectUrl: string }) => {
   return unauth.get(`/oauth/google/userinfo`, { params: { code, redirectUrl } });
 };
+
+export const getGoogleLink = (url: string) => {
+  return unauth.get(`/oauth/google`, { params: { url } });
+};

--- a/src/service/user.ts
+++ b/src/service/user.ts
@@ -1,0 +1,18 @@
+import { LOCAL_KEY } from '~/utils/constant/user';
+import useStorage from '~/hooks/useStorage';
+import axios from 'axios';
+
+const storage = useStorage('local');
+const token = storage.getItem(LOCAL_KEY.token, '');
+
+const authHeader = (token: string) => {
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+};
+
+export const getUerInfo = (token: string) => {
+  return axios.get('/user', authHeader(token));
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,10 @@
+export interface IUser {
+  id: number | null;
+  username: string;
+  email: string;
+  profileUrl: string;
+}
+export interface ICurrentUser {
+  token: string;
+  user: IUser;
+}


### PR DESCRIPTION
close #90 

## ✅ 작업 내용
- Avatar 컴포넌트 props 변경 및 내부 로직 수정
- 구글 로그인 링크 정보 서버 요청하여 받아오도록 변경 (환경변수는 혹시몰라서 아직 삭제 안했어요!)
- 새로고침 시 로그인 유지 및 로그아웃 기능 구현

---
- [x] isLoading 적용
- [x] 모바일 슬라이드 메뉴에 로그인 추가
- [x] 구글 링크 받아오기 실패한 후 링크 클릭 시 alret 처리

## 📌 이슈 사항
- api 응답값의 필드명이 변경될 예정이라 코드가 일부 지저분한 부분이 있습니다.
- refresh 토큰인증과 회원 탈퇴 부분은 이후에 완성시킬 예정입니다.

## ✍ 궁금한 점
- 새로고침 시 토큰값과 일치하는 유저 정보 받아오기 전에 로그인 버튼이 나타나는데 이 부분 isLoading으로 처리하는것 외에는 다른 방법이 없을까요?
- 구글 링크 받아오기 실패할 경우 링크이동 자체가 안되는데 클릭 시 메시지 나타나게 해줘야할까요?