### PR TITLE
Fix/#87 모바일 모달 레이아웃 수정

### DIFF
--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -9,6 +9,8 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   style?: CSSProperties;
   size?: keyof typeof buttonSizes;
   loading?: boolean;
+  startIcon?: ReactNode;
+  endIcon?: ReactNode;
 }
 
 const Button = ({
@@ -17,12 +19,16 @@ const Button = ({
   children,
   size = 'md',
   loading,
+  startIcon,
+  endIcon,
   ...props
 }: ButtonProps) => {
   return (
     <StyledButton buttonType={buttonType} disabled={disabled || loading} size={size} {...props}>
+      {startIcon && <StartIcon>{startIcon}</StartIcon>}
       {loading && <Spinner />}
       <Content className={loading ? 'hidden' : ''}>{children}</Content>
+      {endIcon && <EndIcon>{endIcon}</EndIcon>}
     </StyledButton>
   );
 };
@@ -30,6 +36,9 @@ const Button = ({
 export default Button;
 
 const StyledButton = styled.button<ButtonProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: relative;
   white-space: nowrap;
 
@@ -43,7 +52,19 @@ const StyledButton = styled.button<ButtonProps>`
 `;
 
 const Content = styled.span`
+  line-height: inherit;
+
   &.hidden {
     visibility: hidden;
   }
+`;
+
+const StartIcon = styled.span`
+  margin-left: -3px;
+  margin-right: 6px;
+`;
+
+const EndIcon = styled.span`
+  margin-right: -3px;
+  margin-left: 6px;
 `;

--- a/src/components/common/Article/index.tsx
+++ b/src/components/common/Article/index.tsx
@@ -13,7 +13,8 @@ const Article = ({ full = false, ...props }: ArticleProps) => {
 export default Article;
 
 const StyledArticle = styled.article<{ full: boolean }>`
-  width: ${({ full }) => (full ? '100%' : '440px')};
+  width: 100%;
+  max-width: ${({ full }) => (full ? '100%' : '440px')};
   margin: 0 auto;
   margin-top: 50px;
   padding: ${({ full }) => (full ? '30px 0 50px' : '42px 28px 45px')};

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -43,5 +43,5 @@ const ModalContainer = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  padding: 0 16px;
+  padding: 0 ${({ theme }) => theme.space.mobileSide};
 `;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -38,8 +38,10 @@ const Modal = ({ children, visible = false, onClose, ...props }: ModalProps) => 
 export default Modal;
 
 const ModalContainer = styled.div`
+  width: 100%;
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  padding: 0 16px;
 `;

--- a/src/components/common/MoveButtons/index.tsx
+++ b/src/components/common/MoveButtons/index.tsx
@@ -17,14 +17,22 @@ const MoveButtons = ({
 }: MoveButtonProps) => {
   return (
     <Buttons>
-      <PrevButton buttonType="borderGray" onClick={onPrev} disabled={disabledPrev}>
-        <Icon name="ArrowLeft" size="20" color="gray600" />
-        <span>이전 질문</span>
-      </PrevButton>
-      <NextButton buttonType="borderGray" onClick={onNext} disabled={disabledNext}>
-        <span> 다음 질문</span>
-        <Icon name="ArrowRight" size="20" color="gray600" />
-      </NextButton>
+      <Button
+        buttonType="borderGray"
+        onClick={onPrev}
+        disabled={disabledPrev}
+        startIcon={<Icon name="ArrowLeft" size="16" color="gray600" />}
+      >
+        이전 질문
+      </Button>
+      <Button
+        buttonType="borderGray"
+        onClick={onNext}
+        disabled={disabledNext}
+        endIcon={<Icon name="ArrowRight" size="16" color="gray600" />}
+      >
+        다음 질문
+      </Button>
     </Buttons>
   );
 };
@@ -36,18 +44,4 @@ const Buttons = styled.div`
   display: flex;
   justify-content: space-between;
   margin-top: 56px;
-`;
-
-const PrevButton = styled(Button)`
-  padding-left: 16px;
-  span {
-    display: flex;
-  }
-`;
-
-const NextButton = styled(Button)`
-  padding-right: 16px;
-  span {
-    display: flex;
-  }
 `;

--- a/src/components/domain/question/TailQuestionModal/index.tsx
+++ b/src/components/domain/question/TailQuestionModal/index.tsx
@@ -51,7 +51,7 @@ const TailQuestionModal = ({ title, id, onClose, isOpenModal }: TailQuestionModa
   }, [isOpenModal]);
 
   return (
-    <Container>
+    <StyledArticle>
       <ModalHeader>
         <PageTitle align="left">꼬리 질문 등록</PageTitle>
         <StyledCloseButton onClick={onClose} />
@@ -74,13 +74,13 @@ const TailQuestionModal = ({ title, id, onClose, isOpenModal }: TailQuestionModa
 
         <SubmitButton loading={isLoading}>등록</SubmitButton>
       </Form>
-    </Container>
+    </StyledArticle>
   );
 };
 
 export default TailQuestionModal;
 
-const Container = styled(Article)`
+const StyledArticle = styled(Article)`
   margin-top: 0;
 `;
 

--- a/src/types/declarations.d.ts
+++ b/src/types/declarations.d.ts
@@ -1,5 +1,5 @@
 import '@emotion/react';
-import { ThemeColors, ThemeFontStyle } from './theme';
+import { ThemeColors, ThemeFontStyle, ThemeSpace } from './theme';
 
 declare module '@emotion/react' {
   export interface Theme {
@@ -8,6 +8,9 @@ declare module '@emotion/react' {
     };
     fontStyle: {
       [key in ThemeFontStyle]: string;
+    };
+    space: {
+      [key in ThemeSpace]: string;
     };
   }
 }

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -51,6 +51,9 @@ export const theme = {
       line-height: 1.5;
     `,
   },
+  space: {
+    mobileSide: `16px;`,
+  },
 };
 
 export type ThemeColors = keyof typeof theme.colors;

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -52,9 +52,10 @@ export const theme = {
     `,
   },
   space: {
-    mobileSide: `16px;`,
+    mobileSide: '16px',
   },
 };
 
 export type ThemeColors = keyof typeof theme.colors;
 export type ThemeFontStyle = keyof typeof theme.fontStyle;
+export type ThemeSpace = keyof typeof theme.space;

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -32,9 +32,19 @@ export const theme = {
       font-size: 16px;
       line-height: 1.5;
     `,
+    body1_600: `
+      font-size: 16px;
+      line-height: 1.5;
+      font-weight: 600;
+    `,
     body2: `
       font-size: 14px;
-      line-height: 1.5;
+      line-height: 20px;
+    `,
+    body2_600: `
+      font-size: 14px;
+      line-height: 20px;
+      font-weight: 600;
     `,
     caption: `
       font-size: 13px;


### PR DESCRIPTION
close #87 

## ✅ 작업 내용
- 모바일 화면에서 꼬리질문 모달 레이아웃 틀어지는 부분 수정
- theme fontStyle body1_600, body2_600 추가 및 line-height 수정
- Button 컴포넌트 startIcon, endIcon props 추가

## 📌 이슈 사항
- body2 부분 body2-600의 line-height와 맞춰서 18px으로 하려고 했는데
아마 지금 figma상에는 없지만 해당 폰트로 2줄이상 넘어갈 경우 line-height가 폰트기준 1.4정도는 되어야 할 것 같아서
20px로 변경했는데 효니님 레이아웃에서 변경해야 할 부분이 있다면.. 제가 변경하겠습니다

## ✍ 궁금한 점
- 440+32로 breakpoint 늘리고 싶지 않아서 TailQuestionModal의 container에 padding을 넣었는데 괜찮은가요?
- Button 컴포넌트에서 icon 받을경우 그냥 컴포넌트 자체를 받게 했는데 괜찮을까요?
- 이외에 문제될 부분들이 있다면 말씀해주세요!