### PR TITLE
Feat/#96 프로필 이미지 업로드 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^4.14.5",
     "axios": "^0.27.2",
     "emailjs-com": "^3.2.0",
+    "heic2any": "^0.0.3",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/src/assets/icons/upload.svg
+++ b/src/assets/icons/upload.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.5 17.5H17.5M10 2.5V14.1667M10 14.1667L15.8333 8.33333M10 14.1667L4.16667 8.33333" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -8,6 +8,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;
   style?: CSSProperties;
   size?: keyof typeof buttonSizes;
+  fullWidth?: boolean;
   loading?: boolean;
   startIcon?: ReactNode;
   endIcon?: ReactNode;
@@ -18,16 +19,24 @@ const Button = ({
   disabled,
   children,
   size = 'md',
+  fullWidth,
   loading,
   startIcon,
   endIcon,
   ...props
 }: ButtonProps) => {
   return (
-    <StyledButton buttonType={buttonType} disabled={disabled || loading} size={size} {...props}>
+    <StyledButton
+      isLoading={!!loading}
+      buttonType={buttonType}
+      fullWidth={fullWidth}
+      disabled={disabled || loading}
+      size={size}
+      {...props}
+    >
       {startIcon && <StartIcon>{startIcon}</StartIcon>}
       {loading && <Spinner />}
-      <Content className={loading ? 'hidden' : ''}>{children}</Content>
+      {children}
       {endIcon && <EndIcon>{endIcon}</EndIcon>}
     </StyledButton>
   );
@@ -35,8 +44,8 @@ const Button = ({
 
 export default Button;
 
-const StyledButton = styled.button<ButtonProps>`
-  display: flex;
+const StyledButton = styled.button<ButtonProps & { isLoading: boolean }>`
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   position: relative;
@@ -44,18 +53,12 @@ const StyledButton = styled.button<ButtonProps>`
 
   ${({ buttonType }) => buttonType && buttonStyle[buttonType]};
   ${({ size }) => size && buttonSizes[size]};
+  ${({ fullWidth }) => fullWidth && `width: 100%;`}
+  ${({ isLoading }) => isLoading && `color: transparent;`}
 
   &:disabled {
     opacity: 0.7;
     cursor: not-allowed;
-  }
-`;
-
-const Content = styled.span`
-  line-height: inherit;
-
-  &.hidden {
-    visibility: hidden;
   }
 `;
 

--- a/src/components/base/Button/types.ts
+++ b/src/components/base/Button/types.ts
@@ -37,17 +37,18 @@ export const buttonSizes = {
     font-size: 12px;
     padding: 5px 11px;
     line-height: 20px;
+    font-weight: 500;
   `,
   sm: `
-    ${theme.fontStyle.body2}
+    ${theme.fontStyle.body2_500}
     padding: 8px 12px;
   `,
   md: `
-    ${theme.fontStyle.body2}
+    ${theme.fontStyle.body2_500}
     padding: 12px 26px;
   `,
   lg: `
-    ${theme.fontStyle.body1}
+    ${theme.fontStyle.body1_500}
     padding: 12px 16px;
   `,
 };

--- a/src/components/base/Icon/svg.ts
+++ b/src/components/base/Icon/svg.ts
@@ -16,3 +16,4 @@ export { default as Google } from '~/assets/icons/google.svg';
 export { default as LogoIcon } from '~/assets/icons/logo-icon.svg';
 export { default as Menu } from '~/assets/icons/menu.svg';
 export { default as Hamburger } from '~/assets/icons/hamburger.svg';
+export { default as Upload } from '~/assets/icons/upload.svg';

--- a/src/components/common/Avatar/index.tsx
+++ b/src/components/common/Avatar/index.tsx
@@ -41,4 +41,5 @@ const Container = styled.div<AvatarProps>`
   position: relative;
   border-radius: 50%;
   overflow: hidden;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
 `;

--- a/src/components/domain/profile/EditUserInfo.tsx
+++ b/src/components/domain/profile/EditUserInfo.tsx
@@ -1,17 +1,39 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 import Input from '~/components/base/Input';
 import Label from '~/components/base/Label';
 import AddForm from '~/components/common/AddForm';
 import InputField from '~/components/common/InputField';
+import Modal from '~/components/common/Modal';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
 import EditAvatar from './EditAvatar';
+import ImageEditModal from './ImageEditModal';
 
 interface EditUserInfoProps {
-  onEditImage: () => void;
+  // onEditImage: () => void;
   onEditNickname: (value: string) => void;
 }
 
-const EditUserInfo = ({ onEditImage, onEditNickname }: EditUserInfoProps) => {
+const EditUserInfo = ({ onEditNickname }: EditUserInfoProps) => {
+  const [isOpenModal, setIsOpenModal] = useState(false);
+  const [profileImage, setProfileImage] = useState<string>('');
+
+  const onCloseModal = () => {
+    setIsOpenModal(false);
+  };
+
+  const onClickProfileImage = () => {
+    setIsOpenModal(true);
+  };
+
+  const onChangeProfileImage = (imageUrl: string) => {
+    /* 서버 요청 코드 작성
+    profileImageURL 받아서 setProfileImage 하기 */
+
+    setProfileImage(imageUrl);
+    onCloseModal();
+  };
+
   return (
     <Container>
       <UserInfo>
@@ -33,8 +55,11 @@ const EditUserInfo = ({ onEditImage, onEditNickname }: EditUserInfoProps) => {
       </UserInfo>
       <UserProfile>
         <HideLabel htmlFor="profileImage">프로필 수정</HideLabel>
-        <EditAvatar size="lg" imageUrl="" onClick={onEditImage} />
+        <EditAvatar size="lg" imageUrl={profileImage} onClick={onClickProfileImage} />
       </UserProfile>
+      <Modal visible={isOpenModal} onClose={onCloseModal}>
+        <ImageEditModal onChangeImage={onChangeProfileImage} />
+      </Modal>
     </Container>
   );
 };

--- a/src/components/domain/profile/EditUserInfo.tsx
+++ b/src/components/domain/profile/EditUserInfo.tsx
@@ -5,12 +5,14 @@ import Label from '~/components/base/Label';
 import AddForm from '~/components/common/AddForm';
 import InputField from '~/components/common/InputField';
 import Modal from '~/components/common/Modal';
+import { IUser } from '~/types/user';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
 import EditAvatar from './EditAvatar';
 import ImageEditModal from './ImageEditModal';
 
 interface EditUserInfoProps {
   // onEditImage: () => void;
+  // user: IUser;
   onEditNickname: (value: string) => void;
 }
 

--- a/src/components/domain/profile/ImageEditModal.tsx
+++ b/src/components/domain/profile/ImageEditModal.tsx
@@ -1,0 +1,113 @@
+import styled from '@emotion/styled';
+import React, { ChangeEvent, useEffect, useRef } from 'react';
+import Button from '~/components/base/Button';
+import Icon from '~/components/base/Icon';
+import Article from '~/components/common/Article';
+import { mediaQuery } from '~/utils/helper/mediaQuery';
+import { isValidFileSize, isValidImageFileExtension } from '~/utils/helper/validation';
+
+interface ImageEditModalProps {
+  onChangeImage: (imageUrl: string) => void;
+}
+
+const ImageEditModal = ({ onChangeImage }: ImageEditModalProps) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const onClickUploadButton = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleChangeImage = async (e: ChangeEvent<HTMLInputElement>) => {
+    let imageFile = e.target.files && (e.target.files[0] as File);
+    const MAX_MB = 1;
+
+    if (!imageFile) return;
+
+    if (!isValidImageFileExtension(imageFile)) {
+      alert('jpg, png, gif 파일만 업로드 가능합니다.');
+      return;
+    }
+
+    if (!isValidFileSize(imageFile.size, MAX_MB)) {
+      alert(`최대 ${MAX_MB}MB 까지 업로드 가능합니다.`);
+      return;
+    }
+
+    if (/\.(heic)$/i.test(imageFile.name)) {
+      const heic2any = require('heic2any');
+      imageFile = await heic2any({ blob: imageFile, toType: 'image/jpeg' });
+
+      if (!imageFile) {
+        return;
+      }
+    }
+
+    const reader = new FileReader();
+    reader.readAsDataURL(imageFile);
+    reader.onload = () => {
+      onChangeImage((reader.result as string) || '');
+    };
+  };
+
+  const onChangeDefaultImage = () => {
+    console.log('기본 이미지로 변경');
+  };
+
+  return (
+    <Container>
+      <Button size="lg" buttonType="borderGray" fullWidth onClick={onChangeDefaultImage}>
+        기본 이미지로 변경
+      </Button>
+      <UploadButton size="lg" buttonType="red" fullWidth onClick={onClickUploadButton}>
+        <ButtonText>
+          <StyledIcon name="Upload" size="18" />
+          이미지 업로드
+        </ButtonText>
+        <ButtonDescription>(최대 1MB 이하만 업로드 가능)</ButtonDescription>
+      </UploadButton>
+      <HideInput
+        type="file"
+        accept="image/gif, image/jpeg, image/png"
+        ref={fileInputRef}
+        onChange={handleChangeImage}
+      />
+    </Container>
+  );
+};
+
+export default ImageEditModal;
+
+const Container = styled(Article)`
+  width: 100%;
+  background-color: white;
+  max-width: 400px;
+  padding: 28px;
+  margin-top: 0;
+
+  ${mediaQuery('sm')} {
+    padding-top: ${({ theme }) => theme.space.mobileSide};
+    padding-bottom: ${({ theme }) => theme.space.mobileSide};
+  }
+`;
+
+const UploadButton = styled(Button)`
+  margin-top: 10px;
+  flex-direction: column;
+`;
+
+const ButtonText = styled.span`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const ButtonDescription = styled.span`
+  ${({ theme }) => theme.fontStyle.body2}
+`;
+
+const StyledIcon = styled(Icon)`
+  margin-right: 6px;
+`;
+
+const HideInput = styled.input`
+  display: none;
+`;

--- a/src/context/user.tsx
+++ b/src/context/user.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useCallback, useState } from 'react';
 import useStorage from '~/hooks/useStorage';
-import { getUerInfo } from '~/service/user';
+import { getUserInfo } from '~/service/user';
 import { ICurrentUser } from '~/types/user';
 import { LOCAL_KEY } from '~/utils/constant/user';
 
@@ -44,13 +44,11 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
 
   const updateUser = useCallback(async (token: string) => {
     try {
-      const { data } = await getUerInfo(token);
-
+      const { data } = await getUserInfo(token);
       if (!data) {
         logout();
         return;
       }
-
       setCurrentUser({
         token,
         user: {

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -18,7 +18,8 @@ const Login = () => {
   const requestLogin = async (code: string) => {
     try {
       const res = await googleLogin({ code, redirectUrl: `${window.location.origin}/login` });
-      login({ token: res.data.jwtToken, refreshToken: res.data.refreshToken });
+
+      login({ token: res.data.accessToken, refreshToken: res.data.refreshToken });
       router.push('/');
     } catch (e) {
       alert('로그인에 실패했습니다.');

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -23,11 +23,6 @@ const ProfileEdit = () => {
     // Toast 띄우기
   };
 
-  const onEditImage = () => {
-    alert('프로필 이미지 수정');
-    // 프로필 모달 관련 코드 작성
-  };
-
   const onDeleteAccount = () => {
     if (confirm('확인 버튼을 누르면 계정이 삭제됩니다.')) {
       alert('계정 삭제');
@@ -39,7 +34,7 @@ const ProfileEdit = () => {
   return (
     <Container>
       <PageTitle align="left">회원 정보 수정</PageTitle>
-      <EditUserInfo onEditNickname={onEditNickname} onEditImage={onEditImage} />
+      <EditUserInfo onEditNickname={onEditNickname} />
       <Line />
       <PageTitle align="left">계정 삭제</PageTitle>
       <DeleteAccount onDeleteAccount={onDeleteAccount} />

--- a/src/service/user.ts
+++ b/src/service/user.ts
@@ -13,6 +13,6 @@ const authHeader = (token: string) => {
   };
 };
 
-export const getUerInfo = (token: string) => {
+export const getUserInfo = (token: string) => {
   return axios.get('/user', authHeader(token));
 };

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -32,6 +32,11 @@ export const theme = {
       font-size: 16px;
       line-height: 1.5;
     `,
+    body1_500: `
+      font-size: 16px;
+      line-height: 1.5;
+      font-weight: 500;
+    `,
     body1_600: `
       font-size: 16px;
       line-height: 1.5;
@@ -40,6 +45,11 @@ export const theme = {
     body2: `
       font-size: 14px;
       line-height: 20px;
+    `,
+    body2_500: `
+      font-size: 14px;
+      line-height: 20px;
+      font-weight: 500;
     `,
     body2_600: `
       font-size: 14px;

--- a/src/utils/helper/validation.ts
+++ b/src/utils/helper/validation.ts
@@ -73,3 +73,11 @@ export const isValidCategoryPair = (main: MainType, sub: SubWithAllType) => {
 export const isValidRandomType = (type: unknown) => {
   return isString(type) && ['voice', 'text'].includes(type);
 };
+
+export const isValidImageFileExtension = (file: File) => {
+  return /\.(gif|jpg|jpeg|png|heic)$/i.test(file.name);
+};
+
+export const isValidFileSize = (size: number, maxMB: number) => {
+  return size < 1024 * 1024 * maxMB;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,6 +2716,11 @@ headers-utils@^3.0.2:
   resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-3.0.2.tgz#dfc65feae4b0e34357308aefbcafa99c895e59ef"
   integrity sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==
 
+heic2any@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/heic2any/-/heic2any-0.0.3.tgz#59248665a3646424b1f88c0aaaa1abba3bbd1aae"
+  integrity sha512-1KG0LzZuIPiqyJjwLgGlgrgWd3UBwUE9g5+tOuHy8PbeH2hF0U4gc4ZWT4ChlCmcdISr1xVRimSehsTOPdRXnQ==
+
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
close #96 

## ✅ 작업 내용
- Button 컴포넌트 fullWidth props 추가
- theme body1_500, body2_500 추가
- 프로필 이미지 업로드 모달 및 기능 구현

## 📌 이슈 사항
- edit 페이지 회원 검증 코드 추가하려고 했으나 리액트 쿼리와 로그인 관련 코드와 연관되어 수정할 것이 좀 있을 듯 하여 따로 pr올리겠습니다.
- Button fullWidth는 참아보려다 넣었습니다...

## ✍ 궁금한 점
- 프로필이미지 파일용량 제한.. github이 1MB여서 1MB로 했는데 어떠신가요?
