### PR TITLE
Feat/#102 회원 정보 페이지 구현

### DIFF
--- a/src/components/base/Link.tsx
+++ b/src/components/base/Link.tsx
@@ -45,6 +45,6 @@ export default Link;
 
 const StyledA = styled.a<LinkTypes>`
   ${({ linkType }) => linkType && buttonStyle[linkType]};
-  ${({ linkType }) => linkType && `display: inline-block;`};
+  ${({ size, linkType }) => (size || linkType) && `display: inline-block;`};
   ${({ size }) => size && buttonSizes[size]};
 `;

--- a/src/components/base/Select/index.tsx
+++ b/src/components/base/Select/index.tsx
@@ -6,11 +6,21 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   name?: string;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   selected?: string;
+  withoutDefault?: boolean;
+  defaultText?: string;
 }
-const Select = ({ list, name, onChange, selected, ...props }: SelectProps) => {
+const Select = ({
+  list,
+  name,
+  onChange,
+  selected,
+  withoutDefault = false,
+  defaultText = '선택해 주세요.',
+  ...props
+}: SelectProps) => {
   return (
     <StyledSelect name={name} id={name} onChange={onChange} value={selected} {...props}>
-      <option value="none">선택해주세요</option>
+      {!withoutDefault && <option value="none">{defaultText}</option>}
       {list.map((category, index) => (
         <option key={index} value={category.value}>
           {category.text}

--- a/src/components/common/Header/ProfileDropdown.tsx
+++ b/src/components/common/Header/ProfileDropdown.tsx
@@ -50,7 +50,7 @@ const ProfileDropdown = ({ user: { username, profileUrl } }: ProfileDropdownProp
             </Link>
           </StyledLi>
           <StyledLi>
-            <Link href="/my" onClick={handleClick}>
+            <Link href={`/profile`} onClick={handleClick}>
               마이페이지
             </Link>
           </StyledLi>
@@ -93,6 +93,7 @@ const Content = styled.div`
   border-radius: 4px;
   background-color: ${({ theme }) => theme.colors.white};
   box-shadow: 0px 1px 2px rgba(204, 204, 204, 0.25);
+  z-index: 100;
 
   &::before {
     content: '';

--- a/src/components/common/InputField/SubCategoryField.tsx
+++ b/src/components/common/InputField/SubCategoryField.tsx
@@ -27,6 +27,7 @@ const SubCategoryField = ({
         name="subCategory"
         onChange={handleChange}
         value={selected}
+        defaultText="분류를 선택해 주세요."
       />
       {message && <ErrorMessage message={message} />}
     </InputField>

--- a/src/components/common/InputField/SubCategoryField.tsx
+++ b/src/components/common/InputField/SubCategoryField.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent } from 'react';
 import Label from '~/components/base/Label';
 import Select from '~/components/base/Select';
-import { MainType, SubType, SUB_CATEGORIES } from '~/utils/constant/category';
-import { convertSubCategory } from '~/utils/helper/converter';
+import { MainType, SubType } from '~/utils/constant/category';
 import InputField from '.';
 import ErrorMessage from '../ErrorMessage';
+import { getSubCategorySelectList } from '~/utils/helper/categorySelect';
 
 interface SubCategoryFieldProps {
   mainCategory: MainType;
@@ -23,10 +23,7 @@ const SubCategoryField = ({
     <InputField>
       <Label htmlFor="subCategory">분류</Label>
       <Select
-        list={SUB_CATEGORIES[mainCategory].map((subCode) => ({
-          value: subCode,
-          text: convertSubCategory(subCode),
-        }))}
+        list={getSubCategorySelectList(mainCategory)}
         name="subCategory"
         onChange={handleChange}
         value={selected}

--- a/src/components/common/MiddleCategory/index.tsx
+++ b/src/components/common/MiddleCategory/index.tsx
@@ -9,9 +9,14 @@ interface MiddleCategoryProps {
   currentCategory: SubWithAllType;
 }
 
-const MiddleCategory = ({ subCategories, onSelect, currentCategory }: MiddleCategoryProps) => {
+const MiddleCategory = ({
+  subCategories,
+  onSelect,
+  currentCategory,
+  ...props
+}: MiddleCategoryProps) => {
   return (
-    <CategoryList>
+    <CategoryList {...props}>
       {subCategories.map((subCode) => (
         <li key={subCode} className={subCode === currentCategory ? 'selected' : ''}>
           <button onClick={() => onSelect(subCode)}>{convertSubCategory(subCode)}</button>

--- a/src/components/common/UserProfile/index.tsx
+++ b/src/components/common/UserProfile/index.tsx
@@ -14,9 +14,10 @@ const UserProfile = ({
   avatarSize = 'md',
   fontSize = 'md',
   text,
+  ...props
 }: UserProfileProps) => {
   return (
-    <Container>
+    <Container {...props}>
       <Avatar src={profileUrl} size={avatarSize} />
       <Text fontSize={fontSize}>{text}</Text>
     </Container>

--- a/src/components/common/UserProfile/index.tsx
+++ b/src/components/common/UserProfile/index.tsx
@@ -36,7 +36,7 @@ const textSize = {
 
   lg: `
     margin-left: 12px;
-    ${theme.fontStyle.subtitle1}
+    ${theme.fontStyle.headline1}
   `,
 };
 

--- a/src/components/domain/QuestionList/index.tsx
+++ b/src/components/domain/QuestionList/index.tsx
@@ -10,11 +10,11 @@ interface QuestionListProps extends Omit<QuestionItemProps, 'question'> {
 
 const QuestionList = forwardRef(
   (
-    { questions, currentCategory, onBookmarkToggle }: QuestionListProps,
+    { questions, currentCategory, onBookmarkToggle, ...props }: QuestionListProps,
     ref?: Ref<HTMLLIElement>,
   ) => {
     return (
-      <Container>
+      <Container {...props}>
         {questions.map((question, index) => (
           <QuestionItem
             question={question}
@@ -32,11 +32,9 @@ const QuestionList = forwardRef(
 export default QuestionList;
 
 const Container = styled.ul`
-  margin-top: 32px;
   border-top: 1px solid ${({ theme }) => theme.colors.gray300};
 
   ${mediaQuery('sm')} {
-    margin-top: 0;
     border-top: 0;
   }
 `;

--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -1,0 +1,103 @@
+import styled from '@emotion/styled';
+import { ChangeEvent } from 'react';
+import Select from '~/components/base/Select';
+import QuestionList from '~/components/domain/QuestionList';
+import { questionData } from '~/mocks/data';
+import { IQuestionItem } from '~/types/question';
+import { MainType, SubWithAllType } from '~/utils/constant/category';
+import {
+  getMainCategorySelectList,
+  getSubCategoryWithAllSelectList,
+} from '~/utils/helper/categorySelect';
+
+type WithNone<T> = T | 'none';
+export type TSubQuery = { mainCategory: WithNone<MainType>; subCategory: WithNone<SubWithAllType> };
+
+export type TQueryBookmark = {
+  tab: 'question';
+  subQuery: TSubQuery;
+  content: IQuestionItem[];
+  page: number;
+  totalPage: number;
+};
+
+interface BookmarkProps {
+  query: TQueryBookmark;
+  onChange: (name: 'subQuery', value: TSubQuery) => void;
+}
+
+const Bookmark = ({ query, onChange }: BookmarkProps) => {
+  const handleMainCategory = (e: ChangeEvent<HTMLSelectElement>) =>
+    onChange('subQuery', {
+      mainCategory: e.target.value as WithNone<MainType>,
+      subCategory: 'none',
+    });
+  const handleSubCategory = (e: ChangeEvent<HTMLSelectElement>) =>
+    onChange('subQuery', {
+      ...query.subQuery,
+      subCategory: e.target.value as WithNone<SubWithAllType>,
+    });
+
+  return (
+    <>
+      <StyledDiv>
+        <div>
+          <StyledSelect
+            name="mainCategory"
+            list={getMainCategorySelectList()}
+            onChange={handleMainCategory}
+            selected={query.subQuery.mainCategory}
+          />
+          {query.subQuery.mainCategory !== 'none' && (
+            <StyledSelect
+              name="subCategory"
+              list={getSubCategoryWithAllSelectList(query.subQuery.mainCategory)}
+              onChange={handleSubCategory}
+              selected={query.subQuery.subCategory}
+              key={query.subQuery.mainCategory}
+            />
+          )}
+        </div>
+
+        <PageInfo>
+          {query.page + 1}/{query.totalPage} 페이지
+        </PageInfo>
+      </StyledDiv>
+
+      <QuestionList
+        questions={
+          query.content.length === 0
+            ? (questionData.content as unknown as IQuestionItem[])
+            : query.content
+        }
+        currentCategory={{
+          mainCategory: 'fe',
+          subCategory: 'all',
+        }}
+      />
+    </>
+  );
+};
+
+export default Bookmark;
+
+const StyledDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 19px;
+`;
+
+const StyledSelect = styled(Select)`
+  width: auto;
+  display: inline-block;
+
+  & ~ & {
+    margin-left: 13px;
+  }
+`;
+
+const PageInfo = styled.span`
+  ${({ theme }) => theme.fontStyle.body2}
+  color: ${({ theme }) => theme.colors.gray500};
+`;

--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -10,8 +10,8 @@ import {
   getSubCategoryWithAllSelectList,
 } from '~/utils/helper/categorySelect';
 
-type WithNone<T> = T | 'none';
-export type TSubQuery = { mainCategory: WithNone<MainType>; subCategory: WithNone<SubWithAllType> };
+type WithAll<T> = T | 'all';
+export type TSubQuery = { mainCategory: WithAll<MainType>; subCategory: SubWithAllType };
 
 export type TQueryBookmark = {
   tab: 'question';
@@ -29,13 +29,13 @@ interface BookmarkProps {
 const Bookmark = ({ query, onChange }: BookmarkProps) => {
   const handleMainCategory = (e: ChangeEvent<HTMLSelectElement>) =>
     onChange('subQuery', {
-      mainCategory: e.target.value as WithNone<MainType>,
-      subCategory: 'none',
+      mainCategory: e.target.value as WithAll<MainType>,
+      subCategory: 'all',
     });
   const handleSubCategory = (e: ChangeEvent<HTMLSelectElement>) =>
     onChange('subQuery', {
       ...query.subQuery,
-      subCategory: e.target.value as WithNone<SubWithAllType>,
+      subCategory: e.target.value as SubWithAllType,
     });
 
   return (
@@ -44,17 +44,19 @@ const Bookmark = ({ query, onChange }: BookmarkProps) => {
         <div>
           <StyledSelect
             name="mainCategory"
-            list={getMainCategorySelectList()}
+            list={[{ value: 'all', text: '전체' }, ...getMainCategorySelectList()]}
             onChange={handleMainCategory}
             selected={query.subQuery.mainCategory}
+            withoutDefault
           />
-          {query.subQuery.mainCategory !== 'none' && (
+          {query.subQuery.mainCategory !== 'all' && (
             <StyledSelect
               name="subCategory"
               list={getSubCategoryWithAllSelectList(query.subQuery.mainCategory)}
               onChange={handleSubCategory}
               selected={query.subQuery.subCategory}
               key={query.subQuery.mainCategory}
+              withoutDefault
             />
           )}
         </div>

--- a/src/components/domain/profile/Tab/Comment.tsx
+++ b/src/components/domain/profile/Tab/Comment.tsx
@@ -1,0 +1,111 @@
+import styled from '@emotion/styled';
+import CommentItem from './CommentItem';
+import { ICategoryQuery } from '~/types/question';
+
+/*
+TODO:
+- type 정리
+*/
+
+export type TQueryComment = {
+  tab: 'comment';
+  content: TComment[];
+  page: number;
+  totalPage: number;
+};
+
+export type TComment = {
+  id: number;
+  title: string;
+  nickname: string;
+  content: string;
+  createdAt: string;
+} & ICategoryQuery;
+
+interface CommentProps {
+  content: TComment[];
+}
+
+const Comment = ({ content }: CommentProps) => {
+  return (
+    <StyledUl>
+      {(content.length === 0 ? DUMMY : content).map((comment) => (
+        <CommentItem comment={comment} key={comment.id} />
+      ))}
+    </StyledUl>
+  );
+};
+
+export default Comment;
+
+const StyledUl = styled.ul`
+  border-top: 1px solid ${({ theme }) => theme.colors.gray300};
+`;
+
+const DUMMY: TComment[] = [
+  {
+    id: 1003,
+    title:
+      'Lorem ipsum dolor, sit amet consectetur adipisicing elit. At nulla omnis ex minus quam, similique voluptatum tempora, explicabo veritatis iste mollitia reprehenderit, amet ratione quidem magnam tempore placeat necessitatibus enim.',
+    nickname: 'jini',
+    content:
+      'Lorem ipsum dolor, sit amet consectetur adipisicing elit. At nulla omnis ex minus quam, similique voluptatum tempora, explicabo veritatis iste mollitia reprehenderit, amet ratione quidem magnam tempore placeat necessitatibus enim.',
+    createdAt: '2022-10-25T02:30:02.209669',
+    mainCategory: 'fe',
+    subCategory: 'data_structure/algorithm',
+  },
+  {
+    id: 1004,
+    title: 'useMemo와 useCallback을 설명해주세요.',
+    nickname: 'jini',
+    content: 'asdfasdf',
+    createdAt: '2022-10-25T02:33:53.342431',
+    mainCategory: 'fe',
+    subCategory: 'react',
+  },
+  {
+    id: 1005,
+    title: 'useMemo와 useCallback을 설명해주세요.',
+    nickname: 'jini',
+    content: 'ㅁㅇㄹ\nㅁㄴㅇㄹ',
+    createdAt: '2022-10-25T23:10:52.187376',
+    mainCategory: 'fe',
+    subCategory: 'react',
+  },
+  {
+    id: 1028,
+    title: 'useMemo와 useCallback을 설명해주세요.',
+    nickname: 'jini',
+    content: '궁금해요',
+    createdAt: '2022-11-14T01:26:48.145675',
+    mainCategory: 'fe',
+    subCategory: 'react',
+  },
+  {
+    id: 1029,
+    title: 'useMemo와 useCallback을 설명해주세요.',
+    nickname: 'jini',
+    content: '궁금해요',
+    createdAt: '2022-11-14T01:28:11.061833',
+    mainCategory: 'fe',
+    subCategory: 'react',
+  },
+  {
+    id: 1030,
+    title: 'useMemo와 useCallback을 설명해주세요.',
+    nickname: 'jini',
+    content: '궁금해요!',
+    createdAt: '2022-11-14T01:28:28.187058',
+    mainCategory: 'fe',
+    subCategory: 'react',
+  },
+  {
+    id: 1031,
+    title: 'useMemo와 useCallback을 설명해주세요.',
+    nickname: 'jini',
+    content: 'ee',
+    createdAt: '2022-11-14T01:34:31.799146',
+    mainCategory: 'fe',
+    subCategory: 'react',
+  },
+];

--- a/src/components/domain/profile/Tab/CommentItem.tsx
+++ b/src/components/domain/profile/Tab/CommentItem.tsx
@@ -1,0 +1,85 @@
+import styled from '@emotion/styled';
+import Link from '~/components/base/Link';
+import { convertSubCategory } from '~/utils/helper/converter';
+import { formatDate } from '~/utils/helper/formatting';
+import { mediaQuery } from '~/utils/helper/mediaQuery';
+import { TComment } from './Comment';
+
+interface CommentListProps {
+  comment: TComment;
+}
+
+const CommentItem = ({ comment }: CommentListProps) => {
+  return (
+    <li key={comment.id}>
+      <StyledLink href="">
+        <CategoryName title={convertSubCategory(comment.subCategory)}>
+          <span>{convertSubCategory(comment.subCategory)}</span>
+        </CategoryName>
+
+        <Content>
+          <QuestionTitle title={comment.title}>{comment.title}</QuestionTitle>
+          <CommentContent title={comment.content}>{comment.content}</CommentContent>
+        </Content>
+
+        <CreatedAt>{formatDate(comment.createdAt)}</CreatedAt>
+      </StyledLink>
+    </li>
+  );
+};
+
+export default CommentItem;
+
+const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  padding: 16px 25px 16px 19px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+`;
+
+const CategoryName = styled.div`
+  padding-right: 20px;
+  width: 140px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  ${({ theme }) => theme.fontStyle.body2_500}
+  color: ${({ theme }) => theme.colors.gray600};
+
+  ${mediaQuery('sm')} {
+    width: 100px;
+  }
+`;
+
+const Content = styled.div`
+  overflow: hidden;
+`;
+
+const QuestionTitle = styled.span`
+  display: block;
+  margin-bottom: 8px;
+  ${({ theme }) => theme.fontStyle.body2}
+  color: ${({ theme }) => theme.colors.gray500};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const CommentContent = styled.span`
+  display: block;
+  ${({ theme }) => theme.fontStyle.body1}
+  color: ${({ theme }) => theme.colors.gray800};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const CreatedAt = styled.span`
+  flex-grow: 1;
+  flex-shrink: 0;
+  padding-left: 25px;
+  text-align: right;
+  ${({ theme }) => theme.fontStyle.body2}
+  color: ${({ theme }) => theme.colors.gray500};
+`;

--- a/src/components/domain/profile/Tab/index.tsx
+++ b/src/components/domain/profile/Tab/index.tsx
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+import Link from '~/components/base/Link';
+
+export type TTab = 'question' | 'comment';
+interface Tab {
+  tab: TTab;
+  onChange: (name: 'tab', value: TTab) => void;
+}
+
+const Tab = ({ tab, onChange, ...props }: Tab) => {
+  const getClassName = (linkTab: TTab) => (tab === linkTab ? 'is-active' : undefined);
+
+  return (
+    <StyledNav {...props}>
+      <StyledUl>
+        <li>
+          <StyledLink
+            href={{ pathname: `/profile`, query: { tab: 'question' } }}
+            as={`/profile`}
+            size="lg"
+            className={getClassName('question')}
+            onClick={() => onChange('tab', 'question')}
+          >
+            북마크한 질문 {0}
+          </StyledLink>
+        </li>
+        <li>
+          <StyledLink
+            href={{ pathname: `/profile`, query: { tab: 'comment' } }}
+            size="lg"
+            className={getClassName('comment')}
+            onClick={() => onChange('tab', 'comment')}
+          >
+            작성한 댓글 {0}
+          </StyledLink>
+        </li>
+      </StyledUl>
+    </StyledNav>
+  );
+};
+
+export default Tab;
+
+const StyledNav = styled.nav`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+`;
+
+const StyledUl = styled.ul`
+  display: flex;
+`;
+
+const StyledLink = styled(Link)`
+  position: relative;
+  color: ${({ theme }) => theme.colors.gray600};
+  ${({ theme }) => theme.fontStyle.subtitle1}
+
+  &.is-active {
+    color: ${({ theme }) => theme.colors.gray800};
+
+    ::after {
+      content: '';
+      position: absolute;
+      bottom: -1px;
+      left: 0;
+      width: 100%;
+      height: 2px;
+      background-color: ${({ theme }) => theme.colors.red};
+    }
+  }
+`;

--- a/src/components/domain/profile/UserInfo.tsx
+++ b/src/components/domain/profile/UserInfo.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import Link from '~/components/base/Link';
+import Avatar from '~/components/common/Avatar';
+import { IUser } from '~/types/user';
+
+interface UserInfoProps {
+  user: IUser;
+}
+
+const UserInfo = ({ user, ...props }: UserInfoProps) => {
+  return (
+    <Container {...props}>
+      <Avatar src={user.profileUrl} size="md" />
+      <Username>{user.username || 'jini'}</Username>
+      <Link href={`/profile/edit`} linkType="borderGray" size="sm">
+        회원 정보 수정
+      </Link>
+    </Container>
+  );
+};
+
+export default UserInfo;
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Username = styled.h3`
+  margin-left: 12px;
+  margin-right: 14px;
+  ${({ theme }) => theme.fontStyle.headline1}
+`;

--- a/src/components/domain/profile/UserInfo.tsx
+++ b/src/components/domain/profile/UserInfo.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Link from '~/components/base/Link';
-import Avatar from '~/components/common/Avatar';
+import UserProfile from '~/components/common/UserProfile';
 import { IUser } from '~/types/user';
 
 interface UserInfoProps {
@@ -10,8 +10,7 @@ interface UserInfoProps {
 const UserInfo = ({ user, ...props }: UserInfoProps) => {
   return (
     <Container {...props}>
-      <Avatar src={user.profileUrl} size="md" />
-      <Username>{user.username || 'jini'}</Username>
+      <StyledUserProfile text={user.username || 'jini'} fontSize="lg" />
       <Link href={`/profile/edit`} linkType="borderGray" size="sm">
         회원 정보 수정
       </Link>
@@ -26,8 +25,6 @@ const Container = styled.div`
   align-items: center;
 `;
 
-const Username = styled.h3`
-  margin-left: 12px;
+const StyledUserProfile = styled(UserProfile)`
   margin-right: 14px;
-  ${({ theme }) => theme.fontStyle.headline1}
 `;

--- a/src/components/domain/random/MainCategoryField.tsx
+++ b/src/components/domain/random/MainCategoryField.tsx
@@ -20,6 +20,7 @@ const MainCategoryField = ({ handleChange, selected, message }: MainCategoryFiel
         name="mainCategory"
         onChange={handleChange}
         selected={selected}
+        defaultText="직무를 선택해 주세요."
       />
       {message && <ErrorMessage message={message} />}
     </InputField>

--- a/src/components/domain/random/MainCategoryField.tsx
+++ b/src/components/domain/random/MainCategoryField.tsx
@@ -3,8 +3,7 @@ import Label from '~/components/base/Label';
 import Select from '~/components/base/Select';
 import ErrorMessage from '~/components/common/ErrorMessage';
 import InputField from '~/components/common/InputField';
-import { MAIN_CATEGORIES } from '~/utils/constant/category';
-import { convertMainCategory } from '~/utils/helper/converter';
+import { getMainCategorySelectList } from '~/utils/helper/categorySelect';
 
 interface MainCategoryFieldProps {
   handleChange: (e: ChangeEvent<HTMLSelectElement>) => void;
@@ -17,10 +16,7 @@ const MainCategoryField = ({ handleChange, selected, message }: MainCategoryFiel
     <InputField>
       <Label htmlFor="mainCategory">직무 선택</Label>
       <Select
-        list={MAIN_CATEGORIES.map((mainCode) => ({
-          value: mainCode,
-          text: convertMainCategory(mainCode),
-        }))}
+        list={getMainCategorySelectList()}
         name="mainCategory"
         onChange={handleChange}
         selected={selected}

--- a/src/components/domain/random/SubCategoryField.tsx
+++ b/src/components/domain/random/SubCategoryField.tsx
@@ -32,7 +32,7 @@ const SubCategoryField = ({ mainCategory, subCategories, handleChange }: SubCate
     <StyledInputField>
       <Label htmlFor="subCategories">분류 선택</Label>
 
-      {mainCategory === 'none' && <Notice>직무를 선택해주세요</Notice>}
+      {mainCategory === 'none' && <Notice>직무를 선택해 주세요.</Notice>}
       {mainCategory !== 'none' && (
         <Container>
           <SubCategoryCheckbox

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -140,12 +140,12 @@ const Home: NextPage = () => {
       <MainContent>
         {queryParams && (
           <>
-            <MiddleCategory
+            <StyledMiddleCategory
               subCategories={['all', ...SUB_CATEGORIES[queryParams.mainCategory]]}
               onSelect={onChangeSubCategory}
               currentCategory={queryParams.subCategory}
             />
-            <QuestionList
+            <StyledQuestionList
               ref={setObserverTarget}
               questions={questions}
               currentCategory={{
@@ -158,7 +158,7 @@ const Home: NextPage = () => {
             />
 
             {isMocking() && (
-              <StyledPagination
+              <Pagination
                 totalElements={21}
                 onChange={onChangePage}
                 current={queryParams.page}
@@ -182,6 +182,10 @@ const MainContent = styled(PageContainer)`
   }
 `;
 
-const StyledPagination = styled(Pagination)`
-  margin-top: 29px;
+const StyledMiddleCategory = styled(MiddleCategory)`
+  margin-bottom: 32px;
+`;
+
+const StyledQuestionList = styled(QuestionList)`
+  margin-bottom: 29px;
 `;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -22,7 +22,7 @@ export type TQuery = TQueryBookmark | TQueryComment;
 const Profile = () => {
   const [query, setQuery] = useState<TQuery>({
     tab: 'question',
-    subQuery: { mainCategory: 'fe', subCategory: 'all' },
+    subQuery: { mainCategory: 'all', subCategory: 'all' },
     content: [],
     page: 0,
     totalPage: 5,

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+import PageContainer from '~/components/common/PageContainer';
+import Pagination from '~/components/common/Pagination';
+import Tab, { TTab } from '~/components/domain/profile/Tab';
+import UserInfo from '~/components/domain/profile/UserInfo';
+import Bookmark, { TQueryBookmark, TSubQuery } from '~/components/domain/profile/Tab/Bookmark';
+import Comment, { TQueryComment } from '~/components/domain/profile/Tab/Comment';
+import { IUser } from '~/types/user';
+
+/*
+TODO:
+- useUser 적용
+- api 연결
+- 반응형 대응
+- URI query (/profile?tab=question&page=1) - UI 동기화
+- 더미데이터 제거
+*/
+
+export type TQuery = TQueryBookmark | TQueryComment;
+
+const Profile = () => {
+  const [query, setQuery] = useState<TQuery>({
+    tab: 'question',
+    subQuery: { mainCategory: 'fe', subCategory: 'all' },
+    content: [],
+    page: 0,
+    totalPage: 5,
+  });
+
+  const handlePageChange = (page: number) => handleChange('page', page);
+  const handleChange = (name: string, value: TTab | TSubQuery | number) => {
+    // api 연결 후 응답값으로 setQuery
+    setQuery({ ...query, [name]: value });
+
+    alert(JSON.stringify({ ...query, [name]: value }, null, 2));
+  };
+
+  return (
+    <StyledPageContainer>
+      <StyledUserInfo user={{} as IUser} />
+      <StyledProfileTab tab={query.tab} onChange={handleChange} />
+      <TabContent>
+        {query.tab === 'question' && <Bookmark query={query} onChange={handleChange} />}
+        {query.tab === 'comment' && <Comment content={query.content} />}
+      </TabContent>
+      <Pagination totalElements={query.totalPage * 20} onChange={handlePageChange} />
+    </StyledPageContainer>
+  );
+};
+
+export default Profile;
+
+const StyledPageContainer = styled(PageContainer)`
+  margin-top: 47px;
+`;
+
+const StyledUserInfo = styled(UserInfo)`
+  margin-bottom: 29px;
+`;
+
+const StyledProfileTab = styled(Tab)`
+  margin-bottom: 18px;
+`;
+
+const TabContent = styled.div`
+  margin-bottom: 32px;
+`;

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -7,7 +7,7 @@ export interface IQuestionItem {
   subCategory: SubType;
   viewCount: number;
   commentCount: number;
-  createAt: string;
+  createdAt: string;
   isBookmarked: boolean;
 }
 

--- a/src/utils/helper/categorySelect.ts
+++ b/src/utils/helper/categorySelect.ts
@@ -1,0 +1,23 @@
+import { MainType, MAIN_CATEGORIES, SubWithAllType, SUB_CATEGORIES } from '../constant/category';
+import { convertMainCategory, convertSubCategory } from './converter';
+
+export function getMainCategorySelectList() {
+  return MAIN_CATEGORIES.map((mainCode) => ({
+    value: mainCode,
+    text: convertMainCategory(mainCode),
+  }));
+}
+
+export function getSubCategorySelectList(mainCategory: MainType) {
+  return SUB_CATEGORIES[mainCategory].map((subCode) => ({
+    value: subCode,
+    text: convertSubCategory(subCode),
+  }));
+}
+
+export function getSubCategoryWithAllSelectList(mainCategory: MainType) {
+  return ['all', ...SUB_CATEGORIES[mainCategory]].map((subCode) => ({
+    value: subCode,
+    text: convertSubCategory(subCode as SubWithAllType),
+  }));
+}


### PR DESCRIPTION
close #102 

## ✅ 작업 내용
- 회원 정보 페이지 마크업
- ProfileDropdown z-index 추가
- ProfileDropdown 마이페이지 href 경로 변경

## 📌 이슈 사항
- API 명세서가 나오면 코드 변경할 예정입니다
- 회원 정보 페이지의 상태인 `query`에 `content`값이 있는 게 찜찜한데, react-query 적용할 때 뺄 수 있을 거 같습니다
- Bookmark 컴포넌트에서 더미데이터 보여주는 부분(line 70)에서 타입 오류 해결하려고 아주 이상한 방법을 사용했는데..나중에 제거될 부분입니다😥

## ✍ 궁금한 점
- 컴포넌트 이름이 조금 어색한 거 같은데 더 나은 이름이 있을까요?
- 북마크한 질문에서 메인카테고리 Select에서 '선택해주세요'를 선택하면, 서브카테고리 Select 렌더링을 막았는데 괜찮나요?
- 북마크한 질문/작성한 댓글이 없을 때 어떻게 할까요? 빈 화면? 북마크하러가기/댓글작성하러가기 이동 버튼?