### PR TITLE
Feat/#103 질문 상세 페이지 북마크 기능 및 댓글 조회 연결

### DIFF
--- a/src/components/common/Comment/CommentContent.tsx
+++ b/src/components/common/Comment/CommentContent.tsx
@@ -1,37 +1,43 @@
 import styled from '@emotion/styled';
 import { useContext } from 'react';
 import Icon from '~/components/base/Icon';
+import { useUser } from '~/react-query/hooks/useUser';
+import { ICommentItem } from '~/types/comment';
 import { formatDate } from '~/utils/helper/formatting';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
 import { CommentContext } from './context';
 
 interface CommentContentProps {
-  commentId: number;
-  content: string;
-  createdAt: string;
+  comment: ICommentItem;
 }
-const CommentContent = ({ commentId, content, createdAt }: CommentContentProps) => {
+const CommentContent = ({ comment }: CommentContentProps) => {
   const { onOpenPassword } = useContext(CommentContext);
+  const { user } = useUser();
+
+  const isAnonymous = comment.role === 'ANONYMOUS';
+  const isMyComment = user && user.id === comment.userId;
 
   const handleDelete = () => {
-    onOpenPassword(commentId, 'delete');
+    onOpenPassword(comment.id, 'delete');
   };
 
   const handleEditStart = () => {
-    onOpenPassword(commentId, 'edit');
+    onOpenPassword(comment.id, 'edit');
   };
 
   return (
     <>
       <Content>
-        <p>{content}</p>
+        <p>{comment.content}</p>
       </Content>
       <Info>
-        <CreatedAt>{formatDate(createdAt)}</CreatedAt>
-        <Buttons>
-          <Icon.Button name="Pencil" color="gray500" size="25" onClick={handleEditStart} />
-          <Icon.Button name="Close" color="gray500" size="12" onClick={handleDelete} />
-        </Buttons>
+        <CreatedAt>{formatDate(comment.createdAt)}</CreatedAt>
+        {(isAnonymous || isMyComment) && (
+          <Buttons>
+            <Icon.Button name="Pencil" color="gray500" size="25" onClick={handleEditStart} />
+            <Icon.Button name="Close" color="gray500" size="12" onClick={handleDelete} />
+          </Buttons>
+        )}
       </Info>
     </>
   );

--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -19,20 +19,15 @@ const CommentItem = ({ commentId, comment }: CommentListProps) => {
     <StyledLi>
       <CommentContainer>
         <Writer>
-          <span title={comment.nickname}>{comment.nickname}</span>
+          <span title={comment.username}>{comment.username}</span>
         </Writer>
         {editId !== commentId ? (
-          <CommentContent
-            commentId={commentId}
-            content={comment.content}
-            createdAt={comment.createdAt}
-          />
+          <CommentContent comment={comment} />
         ) : (
           <EditorContainer>
             <EditCommentForm defaultValue={comment.content} commentId={commentId} />
           </EditorContainer>
         )}
-
         {passwordState.commentId === commentId && <PasswordConfirm commentId={commentId} />}
       </CommentContainer>
     </StyledLi>

--- a/src/components/domain/question/PostHeader/index.tsx
+++ b/src/components/domain/question/PostHeader/index.tsx
@@ -1,16 +1,44 @@
 import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import Icon from '~/components/base/Icon';
 import PageTitle from '~/components/base/PageTitle';
+import useBookmark from '~/react-query/hooks/useBookmark';
+import { useUser } from '~/react-query/hooks/useUser';
 import { SubType } from '~/utils/constant/category';
 import { convertSubCategory } from '~/utils/helper/converter';
 
 interface PostHeaderProps {
   subCategory: SubType;
   title: string;
+  questionId: number;
 }
 
-const PostHeader = ({ subCategory, title }: PostHeaderProps) => {
+const PostHeader = ({ subCategory, title, questionId }: PostHeaderProps) => {
+  const { isBookmarked, postBookmark } = useBookmark({ questionId });
+  const { user } = useUser();
+  const router = useRouter();
+
+  const onBookmarkToggle = async () => {
+    if (!user) {
+      alert('로그인이 필요한 서비스입니다.');
+      router.push('/login');
+      return;
+    }
+
+    postBookmark(!isBookmarked);
+  };
+
   return (
     <Container>
+      <StyledIconButton
+        name="Star"
+        width="21"
+        height="20"
+        fill={isBookmarked ? 'red' : 'gray100'}
+        stroke={isBookmarked ? 'red' : 'gray300'}
+        onClick={onBookmarkToggle}
+        aria-label={`북마크 ${isBookmarked ? '삭제' : '추가'}하기`}
+      />
       <CategoryName>{convertSubCategory(subCategory)}</CategoryName>
       <PostTitle>{title}</PostTitle>
     </Container>
@@ -20,9 +48,10 @@ const PostHeader = ({ subCategory, title }: PostHeaderProps) => {
 export default PostHeader;
 
 const Container = styled.div`
+  position: relative;
   text-align: center;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
-  padding-bottom: 22px;
+  padding-bottom: 30px;
 `;
 const CategoryName = styled.div`
   ${({ theme }) => theme.fontStyle.body2};
@@ -31,4 +60,16 @@ const CategoryName = styled.div`
 
 const PostTitle = styled(PageTitle)`
   margin-top: 18px;
+`;
+
+const StyledIconButton = styled(Icon.Button)`
+  width: auto;
+  padding: 7px 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.colors.white};
+  box-shadow: 0px 1px 2px rgba(204, 204, 204, 0.25);
+  position: absolute;
+  top: -8px;
+  right: 18px;
 `;

--- a/src/pages/question/[id]/index.tsx
+++ b/src/pages/question/[id]/index.tsx
@@ -104,7 +104,11 @@ const QuestionDetail = ({ questionId: defaultId, query }: QuestionDetailProps) =
 
   return (
     <Container>
-      <PostHeader subCategory={detailData.subCategory} title={detailData.title} />
+      <PostHeader
+        subCategory={detailData.subCategory}
+        title={detailData.title}
+        questionId={detailData.id}
+      />
       <PostContent>
         <Recorder key={detailData.id} />
         <TailQuestions

--- a/src/pages/random/text/[idx].tsx
+++ b/src/pages/random/text/[idx].tsx
@@ -88,6 +88,7 @@ const RandomText = () => {
         <PageContainer>
           <Article full>
             <PostHeader
+              questionId={curQuestion.id}
               subCategory={curQuestion.subCategory}
               title={isString(curQuestion.title) ? curQuestion.title : ''}
             />

--- a/src/pages/random/voice/[idx].tsx
+++ b/src/pages/random/voice/[idx].tsx
@@ -101,6 +101,7 @@ const RandomVoice = () => {
         <PageContainer>
           <Article full>
             <PostHeader
+              questionId={curQuestion.id}
               subCategory={curQuestion.subCategory}
               title={isString(curQuestion.title) ? curQuestion.title : ''}
             />

--- a/src/react-query/hooks/useBookmark.ts
+++ b/src/react-query/hooks/useBookmark.ts
@@ -1,0 +1,68 @@
+import { useUser } from './useUser';
+import bookmarkApi from '~/service/bookmark';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '../queryKey';
+
+type BookmarkResponse = boolean | undefined;
+
+/**
+ * 연속적으로 북마크 api호출 시 이전 요청 취소되지 않는 이슈 있음.
+ * 또한 연속 요청 시  api 문제 발생
+ */
+
+const useBookmark = ({ questionId }: { questionId: number }) => {
+  const queryClient = useQueryClient();
+  const { user } = useUser();
+
+  const { data: isBookmarked = false } = useQuery(
+    ['bookmark', questionId, user?.id],
+    ({ signal }) => {
+      return bookmarkApi.getBookmark(questionId, signal);
+    },
+    {
+      enabled: !!user,
+      retry: 0,
+    },
+  );
+
+  const setBookmarkData = (data: boolean) => {
+    queryClient.setQueryData([QUERY_KEY.bookmark, questionId, user?.id], data);
+  };
+
+  const { mutate: postBookmark } = useMutation({
+    mutationFn: () => {
+      return bookmarkApi.bookmark(questionId);
+    },
+    onMutate: async (data: boolean) => {
+      await queryClient.cancelQueries({ queryKey: [QUERY_KEY.bookmark, questionId, user?.id] });
+      const prevData: BookmarkResponse = queryClient.getQueryData([
+        'bookmark',
+        questionId,
+        user?.id,
+      ]);
+      queryClient.setQueryData([QUERY_KEY.bookmark, questionId, user?.id], (data) => !data);
+
+      return { prevData: prevData || false };
+    },
+    onSuccess: (data) => {
+      setBookmarkData(data);
+    },
+    onError: (_, __, context) => {
+      if (context?.prevData !== undefined) {
+        setBookmarkData(context.prevData);
+        alert('북마크 요청에 실패했습니다.');
+        return;
+      }
+    },
+    // onSettled: () => {
+    // queryClient.invalidateQueries([QUERY_KEY.bookmark, questionId]);
+    // },
+  });
+
+  return {
+    isBookmarked,
+    postBookmark,
+  };
+};
+
+export default useBookmark;

--- a/src/react-query/queryKey.ts
+++ b/src/react-query/queryKey.ts
@@ -2,4 +2,5 @@ export const QUERY_KEY = {
   questionDetail: 'questionDetail',
   comments: 'comments',
   user: 'user',
+  bookmark: 'bookmark',
 };

--- a/src/service/bookmark.ts
+++ b/src/service/bookmark.ts
@@ -4,6 +4,9 @@ const bookmarkApi = {
   bookmark(questionId: number) {
     return auth.post(`/bookmarks/${questionId}`).then((res) => res.data);
   },
+  getBookmark(questionId: number, signal?: AbortSignal) {
+    return auth.get(`/bookmarks/${questionId}`, { signal }).then((res) => res.data);
+  },
 };
 
 export default bookmarkApi;

--- a/src/service/bookmark.ts
+++ b/src/service/bookmark.ts
@@ -1,0 +1,9 @@
+import { auth } from './base';
+
+const bookmarkApi = {
+  bookmark(questionId: number) {
+    return auth.post(`/bookmarks/${questionId}`).then((res) => res.data);
+  },
+};
+
+export default bookmarkApi;

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,6 +1,8 @@
 export interface ICommentItem {
   id: number;
-  nickname: string;
+  username: string;
+  role: 'ANONYMOUS' | 'USER';
+  userId: number;
   content: string;
   createdAt: string;
 }


### PR DESCRIPTION
close #103 

## ✅ 작업 내용
- 질문 상세조회 북마크 API 연결
- 댓글 조회 회원/비회원 구분하여 나타나도록 수정

## 📌 이슈 사항
- 현재 북마크 부분 낙관적으로 업데이트하는 부분 API 연속 요청 할 경우 에러가 발생해서 일단 debounce로 막아두었습니다.
reactquery로만 쉽게 될 줄 알았는데 토글 요청이다보니 이렇게 쓰는게 맞는 지 확신이 안서서 조금 더 학습 후에 개선 해볼까합니다.
- 댓글 조회 filed명이 변경되어서 조회 부분만 수정해두었습니다. 로그인 유저의 댓글 등록/수정/삭제는 API완성되면 따로 올리려합니다.

## ✍ 궁금한 점
- 북마크 버튼 state 컴포넌트로 관리하기로 이야기 했었지만 서버에서 받는 상태랑 함께 구현하다보니 컴포넌트 만들기가 조금 애매해져서 따로 만들지는 않았는데 북마크 관련 코드 완성되고 리팩토링 하면서 묶는게 나을것 같은데 어떤가요?