### PR TITLE
Feat/#131 홈/회원 정보 페이지 북마크 기능 

### DIFF
--- a/src/components/base/Icon/IconButton.tsx
+++ b/src/components/base/Icon/IconButton.tsx
@@ -1,8 +1,8 @@
-import { CSSProperties, HTMLAttributes } from 'react';
+import { CSSProperties, HTMLAttributes, MouseEvent } from 'react';
 import Icon, { IconProps } from '.';
 
 interface IconButtonProps extends IconProps, Omit<HTMLAttributes<HTMLButtonElement>, 'color'> {
-  onClick?: () => void;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
   type?: 'submit' | 'reset' | 'button' | undefined;
   style?: CSSProperties;
 }

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Icon from '~/components/base/Icon';
 
 const VIEW_PAGE_SIZE = 5;
-const PAGE_SIZE = 20;
+export const PAGE_SIZE = 20;
 const ZERO_INDEX = 1;
 
 interface PaginationProps {
@@ -29,6 +29,10 @@ const Pagination = ({
     setCurrentPage(page);
     onChange(page);
   };
+
+  useEffect(() => {
+    setCurrentPage(current);
+  }, [totalElements]);
 
   return (
     <Container {...props}>

--- a/src/components/domain/QuestionList/BookmarkButton.tsx
+++ b/src/components/domain/QuestionList/BookmarkButton.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import Icon from '~/components/base/Icon';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
 
@@ -9,6 +9,13 @@ export interface BookmarkButtonProps {
 }
 
 const BookmarkButton = ({ isBookmarked, onBookmarkToggle }: BookmarkButtonProps) => {
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (e.target instanceof HTMLButtonElement) {
+      e.target.blur();
+    }
+    onBookmarkToggle();
+  };
+
   return (
     <StyledIconButton
       name="Star"
@@ -16,7 +23,7 @@ const BookmarkButton = ({ isBookmarked, onBookmarkToggle }: BookmarkButtonProps)
       height="20"
       fill={isBookmarked ? 'red' : 'gray100'}
       stroke={isBookmarked ? 'red' : 'gray300'}
-      onClick={onBookmarkToggle}
+      onClick={handleClick}
       aria-label={`북마크 ${isBookmarked ? '삭제' : '추가'}하기`}
     />
   );

--- a/src/components/domain/QuestionList/QuestionItem.tsx
+++ b/src/components/domain/QuestionList/QuestionItem.tsx
@@ -11,18 +11,18 @@ import BookmarkButton from './BookmarkButton';
 export interface QuestionItemProps {
   question: IQuestionItem;
   currentCategory: ICategoryQuery;
-  onBookmarkToggle?: (id: number, isBookmarked: boolean) => void;
+  onBookmarkToggle?: (id: number) => void;
 }
 
 const QuestionItem = ({ question, currentCategory, onBookmarkToggle }: QuestionItemProps) => {
   const handleBookmarkToggle = useCallback(() => {
-    onBookmarkToggle && onBookmarkToggle(question.id, question.isBookmarked);
-  }, [question.id, question.isBookmarked, onBookmarkToggle]);
+    onBookmarkToggle && onBookmarkToggle(question.id);
+  }, [question.id, onBookmarkToggle]);
 
   return (
     <StyledItem>
       <BookmarkButton
-        isBookmarked={question.isBookmarked ?? false}
+        isBookmarked={question.isBookmarked}
         onBookmarkToggle={handleBookmarkToggle}
       />
 

--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -13,7 +13,8 @@ import PageInfo from './PageInfo';
 import { isMainType, isSubWithAllType } from '~/utils/helper/checkType';
 import { isValidCategoryPair } from '~/utils/helper/validation';
 import BookmarkList from './BookmarkList';
-import { useBookmarkProfile } from '~/react-query/hooks/useBookmarkList';
+import useBookmarkList from '~/react-query/hooks/useBookmarkList';
+import { QUERY_KEY } from '~/react-query/queryKey';
 
 type WithAll<T> = T | 'all';
 
@@ -26,7 +27,7 @@ export type TQueryBookmark = {
 const Bookmark = () => {
   const [isReady, setIsReady] = useState(false);
   const { data, query, setQuery } = useProfileBookmark(isReady);
-  const postBookmark = useBookmarkProfile(query);
+  const postBookmark = useBookmarkList(() => [QUERY_KEY.user, QUERY_KEY.bookmark, query]);
   const router = useRouter();
 
   const handleMainCategory = (e: ChangeEvent<HTMLSelectElement>) =>

--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -26,7 +26,13 @@ export type TQueryBookmark = {
 
 const Bookmark = () => {
   const [isReady, setIsReady] = useState(false);
-  const { data, query, setQuery } = useProfileBookmark(isReady);
+  const {
+    data,
+    query,
+    setQuery,
+    hasContentOn,
+    refetch: refetchBookmark,
+  } = useProfileBookmark(isReady);
   const postBookmark = useBookmarkList(() => [QUERY_KEY.user, QUERY_KEY.bookmark, query]);
   const router = useRouter();
 
@@ -38,7 +44,14 @@ const Bookmark = () => {
       subCategory: e.target.value as SubWithAllType,
       page: 0,
     });
-  const handlePage = (page: number) => setQuery({ ...query, page });
+  const handlePage = (page: number) => {
+    const nextPage = hasContentOn(page) ? page : page - 1;
+    setQuery({ ...query, page: nextPage });
+
+    if (nextPage === query.page) {
+      refetchBookmark();
+    }
+  };
 
   const handleBookmarkToggle = (questionId: number) => {
     postBookmark(questionId);
@@ -87,12 +100,7 @@ const Bookmark = () => {
         <PageInfo cur={query.page} total={data.totalPages} />
       </StyledDiv>
       <StyledBookmarkList data={data} onBookmarkToggle={handleBookmarkToggle} />
-      <Pagination
-        current={query.page}
-        totalElements={data.totalElements}
-        onChange={handlePage}
-        key={`${query.mainCategory} ${query.subCategory}`}
-      />
+      <Pagination current={query.page} totalElements={data.totalElements} onChange={handlePage} />
     </>
   );
 };

--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -87,7 +87,12 @@ const Bookmark = () => {
         <PageInfo cur={query.page} total={data.totalPages} />
       </StyledDiv>
       <StyledBookmarkList data={data} onBookmarkToggle={handleBookmarkToggle} />
-      <Pagination totalElements={data.totalElements} onChange={handlePage} />
+      <Pagination
+        current={query.page}
+        totalElements={data.totalElements}
+        onChange={handlePage}
+        key={`${query.mainCategory} ${query.subCategory}`}
+      />
     </>
   );
 };

--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -13,6 +13,7 @@ import PageInfo from './PageInfo';
 import { isMainType, isSubWithAllType } from '~/utils/helper/checkType';
 import { isValidCategoryPair } from '~/utils/helper/validation';
 import BookmarkList from './BookmarkList';
+import { useBookmarkProfile } from '~/react-query/hooks/useBookmarkList';
 
 type WithAll<T> = T | 'all';
 
@@ -25,6 +26,7 @@ export type TQueryBookmark = {
 const Bookmark = () => {
   const [isReady, setIsReady] = useState(false);
   const { data, query, setQuery } = useProfileBookmark(isReady);
+  const postBookmark = useBookmarkProfile(query);
   const router = useRouter();
 
   const handleMainCategory = (e: ChangeEvent<HTMLSelectElement>) =>
@@ -36,6 +38,10 @@ const Bookmark = () => {
       page: 0,
     });
   const handlePage = (page: number) => setQuery({ ...query, page });
+
+  const handleBookmarkToggle = (questionId: number) => {
+    postBookmark(questionId);
+  };
 
   useEffect(() => {
     if (!router.isReady || router.query.tab !== 'bookmark') return;
@@ -79,7 +85,7 @@ const Bookmark = () => {
 
         <PageInfo cur={query.page} total={data.totalPages} />
       </StyledDiv>
-      <StyledBookmarkList data={data} />
+      <StyledBookmarkList data={data} onBookmarkToggle={handleBookmarkToggle} />
       <Pagination totalElements={data.totalElements} onChange={handlePage} />
     </>
   );

--- a/src/components/domain/profile/Tab/BookmarkList.tsx
+++ b/src/components/domain/profile/Tab/BookmarkList.tsx
@@ -6,7 +6,12 @@ import QuestionItem from '../../QuestionList/QuestionItem';
 import styled from '@emotion/styled';
 import { mediaQuery } from '~/utils/helper/mediaQuery';
 
-const BookmarkList = ({ data, ...props }: { data: Paging<IQuestionItem> }) => {
+interface BookmarkListProps {
+  data: Paging<IQuestionItem>;
+  onBookmarkToggle: (questionId: number) => void;
+}
+
+const BookmarkList = ({ data, onBookmarkToggle, ...props }: BookmarkListProps) => {
   if (data.totalElements === 0) return <NoResult {...props}>북마크한 질문이 없습니다.</NoResult>;
   return (
     <Container {...props}>
@@ -18,6 +23,7 @@ const BookmarkList = ({ data, ...props }: { data: Paging<IQuestionItem> }) => {
             mainCategory: question.mainCategory,
             subCategory: question.subCategory,
           }}
+          onBookmarkToggle={onBookmarkToggle}
         />
       ))}
     </Container>

--- a/src/components/domain/profile/Tab/BookmarkList.tsx
+++ b/src/components/domain/profile/Tab/BookmarkList.tsx
@@ -12,7 +12,9 @@ interface BookmarkListProps {
 }
 
 const BookmarkList = ({ data, onBookmarkToggle, ...props }: BookmarkListProps) => {
-  if (data.totalElements === 0) return <NoResult {...props}>북마크한 질문이 없습니다.</NoResult>;
+  if (data.totalElements === 0 || data.content.length === 0) {
+    return <NoResult {...props}>북마크한 질문이 없습니다.</NoResult>;
+  }
   return (
     <Container {...props}>
       {data.content.map((question) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import { mediaQuery } from '~/utils/helper/mediaQuery';
 import Pagination from '~/components/common/Pagination';
 import useUrlState from '~/hooks/useUrlState';
 import useQuestionList from '~/react-query/hooks/useQuestionList';
-import useBookmarkHome from '~/react-query/hooks/useBookmarkList';
+import { useBookmarkHome } from '~/react-query/hooks/useBookmarkList';
 import { useUser } from '~/react-query/hooks/useUser';
 
 type QueryParams = {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -94,7 +94,6 @@ const Home: NextPage = () => {
           totalElements={data.totalElements}
           onChange={onChangePage}
           current={queryParams.page}
-          key={JSON.stringify(queryParams)}
         />
       </MainContent>
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,8 +13,9 @@ import { mediaQuery } from '~/utils/helper/mediaQuery';
 import Pagination from '~/components/common/Pagination';
 import useUrlState from '~/hooks/useUrlState';
 import useQuestionList from '~/react-query/hooks/useQuestionList';
-import { useBookmarkHome } from '~/react-query/hooks/useBookmarkList';
+import useBookmarkList from '~/react-query/hooks/useBookmarkList';
 import { useUser } from '~/react-query/hooks/useUser';
+import { QUERY_KEY } from '~/react-query/queryKey';
 
 type QueryParams = {
   mainCategory: MainType;
@@ -35,7 +36,7 @@ const Home: NextPage = () => {
   const [isReady, setIsReady] = useState(false);
   const [queryParams, setQueryParams] = useUrlState(initialValues);
   const { data } = useQuestionList(queryParams, isReady);
-  const postBookmark = useBookmarkHome(queryParams);
+  const postBookmark = useBookmarkList(() => [QUERY_KEY.question, queryParams]);
 
   const onChangePage = (page: number) => setQueryParams({ ...queryParams, page });
   const onChangeSubCategory = (subCategory: SubWithAllType) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,8 @@ import { mediaQuery } from '~/utils/helper/mediaQuery';
 import Pagination from '~/components/common/Pagination';
 import useUrlState from '~/hooks/useUrlState';
 import useQuestionList from '~/react-query/hooks/useQuestionList';
+import useBookmarkHome from '~/react-query/hooks/useBookmarkList';
+import { useUser } from '~/react-query/hooks/useUser';
 
 type QueryParams = {
   mainCategory: MainType;
@@ -28,15 +30,26 @@ const initialValues: QueryParams = {
 
 const Home: NextPage = () => {
   const router = useRouter();
+  const { user } = useUser();
 
   const [isReady, setIsReady] = useState(false);
   const [queryParams, setQueryParams] = useUrlState(initialValues);
   const { data } = useQuestionList(queryParams, isReady);
+  const postBookmark = useBookmarkHome(queryParams);
 
   const onChangePage = (page: number) => setQueryParams({ ...queryParams, page });
   const onChangeSubCategory = (subCategory: SubWithAllType) => {
     if (queryParams.subCategory === subCategory) return;
     setQueryParams({ ...queryParams, subCategory, page: initialValues.page });
+  };
+  const onBookmarkToggle = (questionId: number) => {
+    if (!user) {
+      alert('로그인이 필요한 서비스입니다.');
+      router.push('/login');
+      return;
+    }
+
+    postBookmark(questionId);
   };
 
   useEffect(() => {
@@ -74,9 +87,7 @@ const Home: NextPage = () => {
             mainCategory: queryParams.mainCategory,
             subCategory: queryParams.subCategory,
           }}
-          onBookmarkToggle={(id) => {
-            alert(`${id} clicked`);
-          }}
+          onBookmarkToggle={onBookmarkToggle}
         />
         <Pagination
           totalElements={data.totalElements}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -11,7 +11,7 @@ import useTab from '~/hooks/useTab';
 
 const Profile = () => {
   const { tab, setTab, TabItem } = useTab(null, { bookmark: Bookmark, comment: Comment });
-  const user = useUser();
+  const currentUser = useUser();
   const router = useRouter();
 
   useEffect(() => {
@@ -28,23 +28,23 @@ const Profile = () => {
   }, [router.isReady]);
 
   useEffect(() => {
-    if (user.isLoading || user.user) return;
+    if (currentUser.isLoading || currentUser.user) return;
 
     alert('잘못된 접근입니다.');
     router.push('/');
-  }, [user.isLoading]);
+  }, [currentUser.isLoading]);
 
   useEffect(() => {
-    user.refetch();
+    currentUser.refetch();
   }, [router.query]);
 
-  if (!user.user) {
+  if (!currentUser.user) {
     return null;
   }
   return (
     <StyledPageContainer>
-      <StyledUserInfo user={user.user} />
-      <StyledProfileTab user={user.user} tab={tab} onChange={setTab} />
+      <StyledUserInfo user={currentUser.user} />
+      <StyledProfileTab user={currentUser.user} tab={tab} onChange={setTab} />
       <TabContent>{TabItem && <TabItem />}</TabContent>
     </StyledPageContainer>
   );

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -11,7 +11,7 @@ import useTab from '~/hooks/useTab';
 
 const Profile = () => {
   const { tab, setTab, TabItem } = useTab(null, { bookmark: Bookmark, comment: Comment });
-  const { user, refetch: userRefetch } = useUser();
+  const user = useUser();
   const router = useRouter();
 
   useEffect(() => {
@@ -28,13 +28,23 @@ const Profile = () => {
   }, [router.isReady]);
 
   useEffect(() => {
-    userRefetch();
-  }, []);
+    if (user.isLoading || user.user) return;
 
+    alert('잘못된 접근입니다.');
+    router.push('/');
+  }, [user.isLoading]);
+
+  useEffect(() => {
+    user.refetch();
+  }, [router.query]);
+
+  if (!user.user) {
+    return null;
+  }
   return (
     <StyledPageContainer>
-      <StyledUserInfo user={user} />
-      <StyledProfileTab user={user} tab={tab} onChange={setTab} />
+      <StyledUserInfo user={user.user} />
+      <StyledProfileTab user={user.user} tab={tab} onChange={setTab} />
       <TabContent>{TabItem && <TabItem />}</TabContent>
     </StyledPageContainer>
   );

--- a/src/react-query/hooks/useBookmarkList.ts
+++ b/src/react-query/hooks/useBookmarkList.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { TQueryBookmark } from '~/components/domain/profile/Tab/Bookmark';
 import bookmarkApi from '~/service/bookmark';
 import { IQuestionItem } from '~/types/question';
 import { Paging } from '~/types/utilityType';
 import { MainType, SubWithAllType } from '~/utils/constant/category';
 import { QUERY_KEY } from '../queryKey';
 
-const useBookmarkHome = (queryParams: {
+export const useBookmarkHome = (queryParams: {
   mainCategory: MainType;
   subCategory: SubWithAllType;
   page: number;
@@ -54,7 +55,53 @@ const useBookmarkHome = (queryParams: {
   return postBookmark;
 };
 
-export default useBookmarkHome;
+export const useBookmarkProfile = (queryParams: TQueryBookmark) => {
+  const queryClient = useQueryClient();
+
+  const setBookmarkData = (data: Paging<IQuestionItem>) => {
+    queryClient.setQueryData([QUERY_KEY.user, QUERY_KEY.bookmark, queryParams], data);
+  };
+
+  const { mutate: postBookmark } = useMutation({
+    mutationFn: (questionId: number) => bookmarkApi.bookmark(questionId),
+    onMutate: async (questionId: number) => {
+      await queryClient.cancelQueries({
+        queryKey: [QUERY_KEY.user, QUERY_KEY.bookmark, queryParams],
+      });
+
+      const prevData: Paging<IQuestionItem> | undefined = queryClient.getQueryData([
+        QUERY_KEY.user,
+        QUERY_KEY.bookmark,
+        queryParams,
+      ]);
+      queryClient.setQueryData(
+        [QUERY_KEY.user, QUERY_KEY.bookmark, queryParams],
+        (prevData: Paging<IQuestionItem> | undefined) =>
+          prevData ? optimisticUpdate(prevData, questionId) : undefined,
+      );
+
+      return { prevData };
+    },
+    onSuccess: (isBookmarked) => {
+      // TODO: alert -> toast로 변경
+      if (isBookmarked) {
+        alert('북마크가 추가되었습니다.');
+      } else {
+        alert('북마크가 제거되었습니다.');
+      }
+    },
+    onError: (_, __, context) => {
+      if (context?.prevData === undefined) {
+        return;
+      }
+
+      setBookmarkData(context.prevData);
+      alert('북마크 요청에 실패했습니다.');
+    },
+  });
+
+  return postBookmark;
+};
 
 function optimisticUpdate(prevData: Paging<IQuestionItem>, questionId: number) {
   const toggleBookmark = (question: IQuestionItem) =>

--- a/src/react-query/hooks/useBookmarkList.ts
+++ b/src/react-query/hooks/useBookmarkList.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import bookmarkApi from '~/service/bookmark';
+import { IQuestionItem } from '~/types/question';
+import { Paging } from '~/types/utilityType';
+import { MainType, SubWithAllType } from '~/utils/constant/category';
+import { QUERY_KEY } from '../queryKey';
+
+const useBookmarkHome = (queryParams: {
+  mainCategory: MainType;
+  subCategory: SubWithAllType;
+  page: number;
+}) => {
+  const queryClient = useQueryClient();
+
+  const setBookmarkData = (data: Paging<IQuestionItem>) => {
+    queryClient.setQueryData([QUERY_KEY.question, queryParams], data);
+  };
+
+  const { mutate: postBookmark } = useMutation({
+    mutationFn: (questionId: number) => bookmarkApi.bookmark(questionId),
+    onMutate: async (questionId: number) => {
+      await queryClient.cancelQueries({ queryKey: [QUERY_KEY.question, queryParams] });
+
+      const prevData: Paging<IQuestionItem> | undefined = queryClient.getQueryData([
+        QUERY_KEY.question,
+        queryParams,
+      ]);
+      queryClient.setQueryData(
+        [QUERY_KEY.question, queryParams],
+        (prevData: Paging<IQuestionItem> | undefined) =>
+          prevData ? optimisticUpdate(prevData, questionId) : undefined,
+      );
+
+      return { prevData };
+    },
+    onSuccess: (isBookmarked) => {
+      // TODO: alert -> toast로 변경
+      if (isBookmarked) {
+        alert('북마크가 추가되었습니다.');
+      } else {
+        alert('북마크가 제거되었습니다.');
+      }
+    },
+    onError: (_, __, context) => {
+      if (context?.prevData === undefined) {
+        return;
+      }
+
+      setBookmarkData(context.prevData);
+      alert('북마크 요청에 실패했습니다.');
+    },
+  });
+
+  return postBookmark;
+};
+
+export default useBookmarkHome;
+
+function optimisticUpdate(prevData: Paging<IQuestionItem>, questionId: number) {
+  const toggleBookmark = (question: IQuestionItem) =>
+    question.id === questionId ? { ...question, isBookmarked: !question.isBookmarked } : question;
+
+  return {
+    ...prevData,
+    content: prevData.content.map(toggleBookmark),
+  };
+}

--- a/src/react-query/hooks/useBookmarkList.ts
+++ b/src/react-query/hooks/useBookmarkList.ts
@@ -1,35 +1,23 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { TQueryBookmark } from '~/components/domain/profile/Tab/Bookmark';
+import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
 import bookmarkApi from '~/service/bookmark';
 import { IQuestionItem } from '~/types/question';
 import { Paging } from '~/types/utilityType';
-import { MainType, SubWithAllType } from '~/utils/constant/category';
-import { QUERY_KEY } from '../queryKey';
 
-export const useBookmarkHome = (queryParams: {
-  mainCategory: MainType;
-  subCategory: SubWithAllType;
-  page: number;
-}) => {
+const useBookmarkList = (queryKeyFn: () => QueryKey) => {
   const queryClient = useQueryClient();
 
   const setBookmarkData = (data: Paging<IQuestionItem>) => {
-    queryClient.setQueryData([QUERY_KEY.question, queryParams], data);
+    queryClient.setQueryData(queryKeyFn(), data);
   };
 
   const { mutate: postBookmark } = useMutation({
     mutationFn: (questionId: number) => bookmarkApi.bookmark(questionId),
     onMutate: async (questionId: number) => {
-      await queryClient.cancelQueries({ queryKey: [QUERY_KEY.question, queryParams] });
+      await queryClient.cancelQueries({ queryKey: queryKeyFn() });
 
-      const prevData: Paging<IQuestionItem> | undefined = queryClient.getQueryData([
-        QUERY_KEY.question,
-        queryParams,
-      ]);
-      queryClient.setQueryData(
-        [QUERY_KEY.question, queryParams],
-        (prevData: Paging<IQuestionItem> | undefined) =>
-          prevData ? optimisticUpdate(prevData, questionId) : undefined,
+      const prevData: Paging<IQuestionItem> | undefined = queryClient.getQueryData(queryKeyFn());
+      queryClient.setQueryData(queryKeyFn(), (prevData: Paging<IQuestionItem> | undefined) =>
+        prevData ? optimisticUpdate(prevData, questionId) : undefined,
       );
 
       return { prevData };
@@ -55,53 +43,7 @@ export const useBookmarkHome = (queryParams: {
   return postBookmark;
 };
 
-export const useBookmarkProfile = (queryParams: TQueryBookmark) => {
-  const queryClient = useQueryClient();
-
-  const setBookmarkData = (data: Paging<IQuestionItem>) => {
-    queryClient.setQueryData([QUERY_KEY.user, QUERY_KEY.bookmark, queryParams], data);
-  };
-
-  const { mutate: postBookmark } = useMutation({
-    mutationFn: (questionId: number) => bookmarkApi.bookmark(questionId),
-    onMutate: async (questionId: number) => {
-      await queryClient.cancelQueries({
-        queryKey: [QUERY_KEY.user, QUERY_KEY.bookmark, queryParams],
-      });
-
-      const prevData: Paging<IQuestionItem> | undefined = queryClient.getQueryData([
-        QUERY_KEY.user,
-        QUERY_KEY.bookmark,
-        queryParams,
-      ]);
-      queryClient.setQueryData(
-        [QUERY_KEY.user, QUERY_KEY.bookmark, queryParams],
-        (prevData: Paging<IQuestionItem> | undefined) =>
-          prevData ? optimisticUpdate(prevData, questionId) : undefined,
-      );
-
-      return { prevData };
-    },
-    onSuccess: (isBookmarked) => {
-      // TODO: alert -> toast로 변경
-      if (isBookmarked) {
-        alert('북마크가 추가되었습니다.');
-      } else {
-        alert('북마크가 제거되었습니다.');
-      }
-    },
-    onError: (_, __, context) => {
-      if (context?.prevData === undefined) {
-        return;
-      }
-
-      setBookmarkData(context.prevData);
-      alert('북마크 요청에 실패했습니다.');
-    },
-  });
-
-  return postBookmark;
-};
+export default useBookmarkList;
 
 function optimisticUpdate(prevData: Paging<IQuestionItem>, questionId: number) {
   const toggleBookmark = (question: IQuestionItem) =>

--- a/src/react-query/hooks/useProfileBookmark.ts
+++ b/src/react-query/hooks/useProfileBookmark.ts
@@ -1,9 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { TQueryBookmark } from '~/components/domain/profile/Tab/Bookmark';
 import userApi from '~/service/user';
 import { QUERY_KEY } from '../queryKey';
 import { useUser } from './useUser';
 import useUrlState from '~/hooks/useUrlState';
+import { IQuestionItem } from '~/types/question';
+import { Paging } from '~/types/utilityType';
+import { PAGE_SIZE } from '~/components/common/Pagination';
 
 const initialState: TQueryBookmark = {
   mainCategory: 'all',
@@ -14,6 +17,7 @@ const initialState: TQueryBookmark = {
 const getBookmark = (query: TQueryBookmark) => userApi.getBookmark(query);
 
 const useProfileBookmark = (isReady: boolean) => {
+  const queryClient = useQueryClient();
   const [query, setQuery] = useUrlState<TQueryBookmark>(initialState, (state) => ({
     tab: 'bookmark',
     ...state,
@@ -22,7 +26,7 @@ const useProfileBookmark = (isReady: boolean) => {
   const { user } = useUser();
 
   const fallback = { content: [], totalPages: 0, totalElements: 0 };
-  const { data = fallback } = useQuery(
+  const { data = fallback, refetch } = useQuery(
     [QUERY_KEY.user, QUERY_KEY.bookmark, query],
     () => getBookmark(query),
     {
@@ -32,7 +36,27 @@ const useProfileBookmark = (isReady: boolean) => {
     },
   );
 
-  return { query, setQuery, data };
+  const hasContentOn = (page: number): boolean => {
+    if (page < data.totalPages - 1) {
+      return true;
+    }
+
+    const curPageData: Paging<IQuestionItem> | undefined = queryClient.getQueryData([
+      QUERY_KEY.user,
+      QUERY_KEY.bookmark,
+      query,
+    ]);
+    if (curPageData === undefined) {
+      return false;
+    }
+
+    const curTotalElements =
+      data.totalElements - curPageData.content.filter(({ isBookmarked }) => !isBookmarked).length;
+    const curTotalPages = Math.floor(curTotalElements / PAGE_SIZE);
+    return page <= curTotalPages;
+  };
+
+  return { query, setQuery, data, hasContentOn, refetch };
 };
 
 export default useProfileBookmark;

--- a/src/react-query/hooks/useQuestionList.ts
+++ b/src/react-query/hooks/useQuestionList.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import questionApi from '~/service/question';
 import { MainType, SubWithAllType } from '~/utils/constant/category';
 import { QUERY_KEY } from '../queryKey';
-import { useUser } from './useUser';
 
 type QueryParams = {
   mainCategory: MainType;
@@ -11,12 +10,10 @@ type QueryParams = {
 };
 
 const useQuestionList = (queryParams: QueryParams, isReady: boolean) => {
-  const { user } = useUser();
-
   const fallback = { content: [], totalElements: 0 };
   const { data = fallback, ...rest } = useQuery(
-    [QUERY_KEY.question, queryParams, user?.id],
-    () => questionApi.getList(queryParams),
+    [QUERY_KEY.question, queryParams],
+    ({ signal }) => questionApi.getList(queryParams, signal),
     {
       keepPreviousData: true,
       staleTime: 0,

--- a/src/react-query/hooks/useUser.ts
+++ b/src/react-query/hooks/useUser.ts
@@ -11,6 +11,7 @@ interface UseUser {
   clearUser: () => void;
   fetchUser: () => Promise<IUser | null>;
   refetch: () => Promise<QueryObserverResult<IUser>>;
+  isLoading: boolean;
 }
 
 const tokenToUserData = async (token: string) => {
@@ -27,7 +28,11 @@ export const useUser = (): UseUser => {
     return tokenToUserData(token);
   };
 
-  const { data: user = null, refetch } = useQuery<IUser>([QUERY_KEY.user], queryFn, {
+  const {
+    data: user = null,
+    refetch,
+    isLoading,
+  } = useQuery<IUser>([QUERY_KEY.user], queryFn, {
     onError: () => {
       clearUser();
     },
@@ -62,5 +67,6 @@ export const useUser = (): UseUser => {
     clearUser,
     fetchUser,
     refetch,
+    isLoading,
   };
 };

--- a/src/service/bookmark.ts
+++ b/src/service/bookmark.ts
@@ -1,10 +1,10 @@
 import { auth } from './base';
 
 const bookmarkApi = {
-  bookmark(questionId: number) {
+  bookmark(questionId: number): Promise<boolean> {
     return auth.post(`/bookmarks/${questionId}`).then((res) => res.data);
   },
-  getBookmark(questionId: number, signal?: AbortSignal) {
+  getBookmark(questionId: number, signal?: AbortSignal): Promise<boolean> {
     return auth.get(`/bookmarks/${questionId}`, { signal }).then((res) => res.data);
   },
 };

--- a/src/service/question.ts
+++ b/src/service/question.ts
@@ -2,6 +2,7 @@ import { auth, unauth } from './base';
 import { IQuestion, IQuestionItem, ICategoryQuery, IQuestionDetail } from '~/types/question';
 import { MainType } from '~/utils/constant/category';
 import { AxiosResponse } from 'axios';
+import { Paging } from '~/types/utilityType';
 
 const questionApi = {
   create(question: IQuestion): RequestType<{ id: number }> {
@@ -14,8 +15,9 @@ const questionApi = {
     params: ICategoryQuery & {
       page: number;
     },
-  ): Promise<TList> {
-    return auth.get('/questions', { params }).then((res) => res.data);
+    signal?: AbortSignal,
+  ): Promise<Paging<IQuestionItem>> {
+    return auth.get('/questions', { params, signal }).then((res) => res.data);
   },
   getDetail(id: number, params: ICategoryQuery): Promise<IQuestionDetail> {
     return unauth.get(`/questions/${id}`, { params }).then((res) => res.data);
@@ -31,11 +33,3 @@ const questionApi = {
 export default questionApi;
 
 type RequestType<T> = Promise<AxiosResponse<T, any>>;
-type TList = {
-  content: IQuestionItem[];
-  totalPages: number;
-  totalElements: number;
-};
-type TDetail = IQuestionItem & {
-  tailQuestions: string[];
-};


### PR DESCRIPTION
close #131 

## ✅ 작업 내용
- 홈 페이지
  - 북마크 API 연결
- 회원 정보 페이지 
  - 북마크 API 연결
  - 유저 검증 추가
  - URL과 Pagination UI가 일치하지 않는 문제 수정

## 📌 이슈 사항
- 홈/회원 정보 페이지에서 뒤로가기 시 URL과 UI가 일치하지 않는 문제가 있습니다😭. 각각 다른 PR로 작업해서 올리겠습니다.
- 북마크 mutation hook인 `useBookmarkList` 쿼리키를 페이지에서 전달하고 있는 게 안 좋은 거 같아서 [query key factory](https://tkdodo.eu/blog/effective-react-query-keys#effective-react-query-keys) 나 다른 사례 찾아보고 개선하겠습니다.

## ✍ 궁금한 점
- 회원 정보 페이지 진입할 때 유저 검증 추가하느라 `useUser`에서 `isLoading` 가져왔는데 괜찮나요? 다른 방법이 있을까요? 
- 회원 정보 페이지에서 북마크 제거한 후 다음 페이지로 이동했을 때 북마크가 없는 경우가 있어 "북마크한 질문이 없습니다."로 처리했는데 괜찮은 것 같나요..?
  ![no bookmark](https://user-images.githubusercontent.com/96400112/206916509-131f0b6c-3f41-4883-977c-a36dbe4fa6d7.gif)
- 리액트쿼리 훅 파일이 많아지면서 파일 관리가 어려워질 거 같은데 아래처럼 quries/mutations로 분리하는 건 어떤가요👀?
  
  <img src="https://user-images.githubusercontent.com/96400112/206917360-d57e75d4-74d9-4586-ab68-7f0caee787f2.png" 
 width="80%" />
