### PR TITLE
Feat/#137 로그아웃 시 이전페이지로 이동, 로그인 에러 시 로그인버튼 나타나도록

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -18,14 +18,12 @@ const Header = () => {
   const router = useRouter();
   const [selectedCategory, setSelectedCategory] = useState('');
   const [isOpen, setIsOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const { user, fetchUser } = useUser();
+  const { user, fetchUser, isLoading } = useUser();
   const { logout } = useAuth();
   const storage = useStorage('local');
 
   const getUserProfile = async () => {
     const token = storage.getItem(LOCAL_KEY.token, '');
-    setIsLoading(true);
 
     // 로컬에서 토큰 삭제 시
     if (user && !token) {
@@ -36,8 +34,6 @@ const Header = () => {
     if (token && !user) {
       await fetchUser();
     }
-
-    setIsLoading(false);
   };
 
   useEffect(() => {

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -6,7 +6,7 @@ interface objectType {
 
 interface useFormProps<T extends objectType> {
   initialValues: T;
-  onSubmit: (e?: FormEvent) => Promise<void>;
+  onSubmit: (e?: FormEvent) => Promise<void> | void;
   validate?: (values: T) => T | objectType;
 }
 

--- a/src/hooks/useUserWithGuard.ts
+++ b/src/hooks/useUserWithGuard.ts
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useUser } from '~/react-query/hooks/useUser';
+
+const useUserWithGuard = () => {
+  const currentUser = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (currentUser.isLoading || currentUser.user) return;
+
+    router.push('/');
+  }, [currentUser.isLoading, currentUser.user]);
+
+  return {
+    ...currentUser,
+  };
+};
+
+export default useUserWithGuard;

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -1,13 +1,11 @@
 import styled from '@emotion/styled';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import PageTitle from '~/components/base/PageTitle';
 import PageContainer from '~/components/common/PageContainer';
 import DeleteAccount from '~/components/domain/profile/DeleteAccount';
 import EditUserInfo from '~/components/domain/profile/EditUserInfo';
+import useUserWithGuard from '~/hooks/useUserWithGuard';
 import { useAuth } from '~/react-query/hooks/useAuth';
 import { useEditProfile } from '~/react-query/hooks/useEditProfile';
-import { useUser } from '~/react-query/hooks/useUser';
 import { SUBMIT_CHECK } from '~/utils/helper/validation';
 
 /*
@@ -17,10 +15,9 @@ import { SUBMIT_CHECK } from '~/utils/helper/validation';
 */
 
 const ProfileEdit = () => {
-  const { user, fetchUser } = useUser();
   const { deleteAccount } = useAuth();
-  const router = useRouter();
   const { editUsername } = useEditProfile();
+  const { user } = useUserWithGuard();
 
   const onEditNickname = (value: string) => {
     if (SUBMIT_CHECK.nickname.isValid(value)) {
@@ -38,21 +35,6 @@ const ProfileEdit = () => {
       deleteAccount(user.id);
     }
   };
-
-  const checkUser = async () => {
-    const user = await fetchUser();
-
-    if (!user) {
-      alert('잘못된 접근입니다.');
-      router.push('/');
-    }
-  };
-
-  useEffect(() => {
-    if (!user) {
-      checkUser();
-    }
-  }, []);
 
   if (!user) {
     return null;

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -5,13 +5,13 @@ import Tab from '~/components/domain/profile/Tab';
 import UserInfo from '~/components/domain/profile/UserInfo';
 import Bookmark from '~/components/domain/profile/Tab/Bookmark';
 import Comment from '~/components/domain/profile/Tab/Comment';
-import { useUser } from '~/react-query/hooks/useUser';
 import { useRouter } from 'next/router';
 import useTab from '~/hooks/useTab';
+import useUserWithGuard from '~/hooks/useUserWithGuard';
 
 const Profile = () => {
   const { tab, setTab, TabItem } = useTab(null, { bookmark: Bookmark, comment: Comment });
-  const currentUser = useUser();
+  const currentUser = useUserWithGuard();
   const router = useRouter();
 
   useEffect(() => {
@@ -26,13 +26,6 @@ const Profile = () => {
         setTab('bookmark');
     }
   }, [router.isReady]);
-
-  useEffect(() => {
-    if (currentUser.isLoading || currentUser.user) return;
-
-    alert('잘못된 접근입니다.');
-    router.push('/');
-  }, [currentUser.isLoading]);
 
   useEffect(() => {
     currentUser.refetch();

--- a/src/pages/question/create.tsx
+++ b/src/pages/question/create.tsx
@@ -10,7 +10,8 @@ import TitleField from '~/components/common/InputField/TitleField';
 import PageContainer from '~/components/common/PageContainer';
 import MainCategoryField from '~/components/domain/random/MainCategoryField';
 import useForm from '~/hooks/useForm';
-import questionApi from '~/service/question';
+import useUserWithGuard from '~/hooks/useUserWithGuard';
+import useCreateQuestion from '~/react-query/hooks/useCreateQuestion';
 import { IQuestion } from '~/types/question';
 import { MainType, SubType } from '~/utils/constant/category';
 import { SUBMIT_CHECK } from '~/utils/helper/validation';
@@ -51,22 +52,17 @@ const validate = (values: initialValuesType) => {
 
 const CreateQuestion = () => {
   const [tailQuestions, setTailQuestions] = useState<string[]>([]);
-  const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
+  const { values, errors, handleChange, handleSubmit } = useForm({
     initialValues,
     onSubmit,
     validate,
   });
-  const router = useRouter();
+  const user = useUserWithGuard();
+  const createQuestion = useCreateQuestion();
 
-  async function onSubmit() {
+  function onSubmit() {
     const newQuestion: IQuestion = { ...values, tailQuestions };
-    try {
-      await questionApi.create(newQuestion);
-      alert('질문이 접수되었습니다. 질문은 관리자 확인 후 등록됩니다.');
-      router.push('/');
-    } catch {
-      alert('질문 등록에 실패했습니다.');
-    }
+    createQuestion.mutate(newQuestion);
   }
 
   const onAddQuestion = (value: string) => {
@@ -87,6 +83,8 @@ const CreateQuestion = () => {
     const updateList = tailQuestions.filter((_, idx) => idx !== index);
     setTailQuestions(updateList);
   };
+
+  if (!user) return null;
 
   return (
     <PageContainer>
@@ -112,7 +110,7 @@ const CreateQuestion = () => {
             list={tailQuestions}
             onRemove={onRemoveQuestion}
           />
-          <SubmitButton onClick={handleSubmit} loading={isLoading}>
+          <SubmitButton onClick={handleSubmit} loading={createQuestion.isLoading}>
             등록
           </SubmitButton>
         </FormContainer>

--- a/src/react-query/hooks/useCreateQuestion.ts
+++ b/src/react-query/hooks/useCreateQuestion.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import questionApi from '~/service/question';
+
+const useCreateQuestion = () => {
+  const router = useRouter();
+
+  return useMutation(questionApi.create, {
+    onSuccess: () => {
+      alert('질문이 접수되었습니다. 질문은 관리자 확인 후 등록됩니다.');
+      router.push('/');
+    },
+    onError: () => {
+      alert('질문 등록에 실패했습니다.');
+    },
+  });
+};
+
+export default useCreateQuestion;

--- a/src/service/question.ts
+++ b/src/service/question.ts
@@ -6,7 +6,7 @@ import { Paging } from '~/types/utilityType';
 
 const questionApi = {
   create(question: IQuestion): RequestType<{ id: number }> {
-    return unauth.post('/questions', question);
+    return auth.post('/questions', question);
   },
   edit(id: number, question: Omit<IQuestion, 'nickname'>) {
     return unauth.put(`/questions/${id}`, question);


### PR DESCRIPTION
close #137 

## ✅ 작업 내용
- 로그인 유저 조회 에러 시 로그인 버튼 보이지 않던 부분 수정
- 유저 검증 필요한 페이지 useUserWidthGuard로 변경
- 질문 등록 페이지 로그인 회원만 접근할 수 있도록 변경
- 질문 등록 api mutation으로 변경

## 📌 이슈 사항
- useUserWidthGuard은 이야기한대로 일단 hook으로 하고 이후에 개선 방향 생각해보도록 하겠습니다.

## ✍ 궁금한 점
- 개선하면 좋을 부분이 있다면 코멘트 부탁드립니다!