### PR TITLE
Fix/#134 회원 정보 페이지 뒤로가기 문제 및 내부 컴포넌트 타입 변경

### DIFF
--- a/src/components/domain/profile/Tab/Bookmark.tsx
+++ b/src/components/domain/profile/Tab/Bookmark.tsx
@@ -32,6 +32,7 @@ const Bookmark = () => {
     setQuery,
     hasContentOn,
     refetch: refetchBookmark,
+    setQueryWithoutUrl,
   } = useProfileBookmark(isReady);
   const postBookmark = useBookmarkList(() => [QUERY_KEY.user, QUERY_KEY.bookmark, query]);
   const router = useRouter();
@@ -58,7 +59,7 @@ const Bookmark = () => {
   };
 
   useEffect(() => {
-    if (!router.isReady || router.query.tab !== 'bookmark') return;
+    if (!router.isReady || (router.query.tab && router.query.tab !== 'bookmark')) return;
 
     const initialValues = { mainCategory: 'all', subCategory: 'all', page: 0 } as TQueryBookmark;
     const filteredQuery = filter(
@@ -70,9 +71,9 @@ const Bookmark = () => {
       initialValues,
     );
 
-    setQuery(filteredQuery);
+    setQueryWithoutUrl(filteredQuery);
     setIsReady(true);
-  }, [router.isReady]);
+  }, [router.isReady, router.query]);
 
   return (
     <>
@@ -100,7 +101,12 @@ const Bookmark = () => {
         <PageInfo cur={query.page} total={data.totalPages} />
       </StyledDiv>
       <StyledBookmarkList data={data} onBookmarkToggle={handleBookmarkToggle} />
-      <Pagination current={query.page} totalElements={data.totalElements} onChange={handlePage} />
+      <Pagination
+        current={query.page}
+        totalElements={data.totalElements}
+        onChange={handlePage}
+        key={query.page}
+      />
     </>
   );
 };

--- a/src/components/domain/profile/Tab/Comment.tsx
+++ b/src/components/domain/profile/Tab/Comment.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 
 const Comment = () => {
   const [isReady, setIsReady] = useState(false);
-  const { data, query, setQuery } = useProfileComment(isReady);
+  const { data, query, setQuery, setQueryWithoutUrl } = useProfileComment(isReady);
   const router = useRouter();
 
   const handlePage = (page: number) => setQuery({ ...query, page });
@@ -19,9 +19,9 @@ const Comment = () => {
     const initialValues = { page: 0 };
     const filteredQuery = filter({ page: router.query.page }, initialValues);
 
-    setQuery(filteredQuery);
+    setQueryWithoutUrl(filteredQuery);
     setIsReady(true);
-  }, [router.isReady]);
+  }, [router.isReady, router.query.page]);
 
   if (data.totalElements === 0) return <NoResult>작성한 댓글이 없습니다.</NoResult>;
   return (
@@ -32,7 +32,12 @@ const Comment = () => {
         ))}
       </StyledUl>
 
-      <Pagination current={query.page} totalElements={data.totalElements} onChange={handlePage} />
+      <Pagination
+        current={query.page}
+        totalElements={data.totalElements}
+        onChange={handlePage}
+        key={query.page}
+      />
     </>
   );
 };

--- a/src/components/domain/profile/Tab/index.tsx
+++ b/src/components/domain/profile/Tab/index.tsx
@@ -4,7 +4,7 @@ import { IUser } from '~/types/user';
 import { Nullable } from '~/types/utilityType';
 
 interface Tab {
-  user: Nullable<IUser>;
+  user: IUser;
   tab: Nullable<string>;
   onChange: (value: string) => void;
 }
@@ -23,7 +23,7 @@ const Tab = ({ user, tab, onChange, ...props }: Tab) => {
             className={getClassName('bookmark')}
             onClick={() => onChange('bookmark')}
           >
-            북마크한 질문 {user?.bookmarkSize}
+            북마크한 질문 {user.bookmarkSize}
           </StyledLink>
         </li>
         <li>
@@ -33,7 +33,7 @@ const Tab = ({ user, tab, onChange, ...props }: Tab) => {
             className={getClassName('comment')}
             onClick={() => onChange('comment')}
           >
-            작성한 댓글 {user?.commentSize}
+            작성한 댓글 {user.commentSize}
           </StyledLink>
         </li>
       </StyledUl>

--- a/src/components/domain/profile/UserInfo.tsx
+++ b/src/components/domain/profile/UserInfo.tsx
@@ -2,16 +2,15 @@ import styled from '@emotion/styled';
 import Link from '~/components/base/Link';
 import UserProfile from '~/components/common/UserProfile';
 import { IUser } from '~/types/user';
-import { Nullable } from '~/types/utilityType';
 
 interface UserInfoProps {
-  user: Nullable<IUser>;
+  user: IUser;
 }
 
 const UserInfo = ({ user, ...props }: UserInfoProps) => {
   return (
     <Container {...props}>
-      <StyledUserProfile profileUrl={user?.profileUrl} text={user?.username ?? ''} fontSize="lg" />
+      <StyledUserProfile profileUrl={user.profileUrl} text={user.username} fontSize="lg" />
       <Link href={`/profile/edit`} variant="borderGray" size="sm">
         회원 정보 수정
       </Link>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -25,7 +25,7 @@ const Profile = () => {
       default:
         setTab('bookmark');
     }
-  }, [router.isReady]);
+  }, [router.isReady, router.query.tab]);
 
   useEffect(() => {
     if (currentUser.isLoading || currentUser.user) return;

--- a/src/react-query/hooks/useProfileBookmark.ts
+++ b/src/react-query/hooks/useProfileBookmark.ts
@@ -18,10 +18,13 @@ const getBookmark = (query: TQueryBookmark) => userApi.getBookmark(query);
 
 const useProfileBookmark = (isReady: boolean) => {
   const queryClient = useQueryClient();
-  const [query, setQuery] = useUrlState<TQueryBookmark>(initialState, (state) => ({
-    tab: 'bookmark',
-    ...state,
-  }));
+  const [query, setQuery, setQueryWithoutUrl] = useUrlState<TQueryBookmark>(
+    initialState,
+    (state) => ({
+      tab: 'bookmark',
+      ...state,
+    }),
+  );
 
   const { user } = useUser();
 
@@ -56,7 +59,7 @@ const useProfileBookmark = (isReady: boolean) => {
     return page <= curTotalPages;
   };
 
-  return { query, setQuery, data, hasContentOn, refetch };
+  return { query, setQuery, setQueryWithoutUrl, data, hasContentOn, refetch };
 };
 
 export default useProfileBookmark;

--- a/src/react-query/hooks/useProfileComment.ts
+++ b/src/react-query/hooks/useProfileComment.ts
@@ -15,7 +15,7 @@ type Params = {
 const getComment = (query: Params) => userApi.getComment(query);
 
 const useProfileComment = (isReady: boolean) => {
-  const [query, setQuery] = useUrlState<Params>(initialState, (state) => ({
+  const [query, setQuery, setQueryWithoutUrl] = useUrlState<Params>(initialState, (state) => ({
     tab: 'comment',
     ...state,
   }));
@@ -33,7 +33,7 @@ const useProfileComment = (isReady: boolean) => {
     },
   );
 
-  return { query, setQuery, data };
+  return { query, setQuery, setQueryWithoutUrl, data };
 };
 
 export default useProfileComment;


### PR DESCRIPTION
close #134 

## ✅ 작업 내용
- 회원 정보 페이지에서 뒤로가기하면 UI이 URL에 맞게 갱신되지 않는 문제
- 사용자 데이터를 사용하는 컴포넌트들 타입 변경

## ✍ 궁금한 점
- 개선할 점이 있다면 알려주세요!