### PR TITLE
Fix/#160 SEO 적용 안 되는 문제

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -73,32 +73,32 @@ const Home: NextPage = () => {
     }
   }, [router.isReady, router.query]);
 
-  if (!isReady) return null;
   return (
-    <div>
+    <>
       <SEO title="Developer Wiki" />
-
-      <MainContent>
-        <StyledMiddleCategory
-          subCategories={['all', ...SUB_CATEGORIES[query.mainCategory]]}
-          onSelect={onChangeSubCategory}
-          currentCategory={query.subCategory}
-        />
-        <StyledQuestionList
-          questions={data.content}
-          currentCategory={{
-            mainCategory: query.mainCategory,
-            subCategory: query.subCategory,
-          }}
-          onBookmarkToggle={onBookmarkToggle}
-        />
-        <Pagination
-          totalElements={data.totalElements}
-          onChange={onChangePage}
-          current={query.page}
-        />
-      </MainContent>
-    </div>
+      {isReady && (
+        <MainContent>
+          <StyledMiddleCategory
+            subCategories={['all', ...SUB_CATEGORIES[query.mainCategory]]}
+            onSelect={onChangeSubCategory}
+            currentCategory={query.subCategory}
+          />
+          <StyledQuestionList
+            questions={data.content}
+            currentCategory={{
+              mainCategory: query.mainCategory,
+              subCategory: query.subCategory,
+            }}
+            onBookmarkToggle={onBookmarkToggle}
+          />
+          <Pagination
+            totalElements={data.totalElements}
+            onChange={onChangePage}
+            current={query.page}
+          />
+        </MainContent>
+      )}
+    </>
   );
 };
 

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -37,20 +37,18 @@ const ProfileEdit = () => {
     }
   };
 
-  if (!user) {
-    return null;
-  }
-
   return (
     <>
       <SEO title="회원 정보 수정" withSuffix />
-      <Container>
-        <PageTitle align="left">회원 정보 수정</PageTitle>
-        <EditUserInfo user={user} onEditNickname={onEditNickname} />
-        <Line />
-        <PageTitle align="left">계정 삭제</PageTitle>
-        <DeleteAccount onDeleteAccount={onDeleteAccount} />
-      </Container>
+      {user && (
+        <Container>
+          <PageTitle align="left">회원 정보 수정</PageTitle>
+          <EditUserInfo user={user} onEditNickname={onEditNickname} />
+          <Line />
+          <PageTitle align="left">계정 삭제</PageTitle>
+          <DeleteAccount onDeleteAccount={onDeleteAccount} />
+        </Container>
+      )}
     </>
   );
 };

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -32,17 +32,16 @@ const Profile = () => {
     currentUser.refetch();
   }, [router.query]);
 
-  if (!currentUser.user) {
-    return null;
-  }
   return (
     <>
-      <SEO title={currentUser.user.username || '프로필'} withSuffix />
-      <StyledPageContainer>
-        <StyledUserInfo user={currentUser.user} />
-        <StyledProfileTab user={currentUser.user} tab={tab} onChange={setTab} />
-        <TabContent>{TabItem && <TabItem />}</TabContent>
-      </StyledPageContainer>
+      <SEO title={currentUser.user?.username ?? '프로필'} withSuffix />
+      {currentUser.user && (
+        <StyledPageContainer>
+          <StyledUserInfo user={currentUser.user} />
+          <StyledProfileTab user={currentUser.user} tab={tab} onChange={setTab} />
+          <TabContent>{TabItem && <TabItem />}</TabContent>
+        </StyledPageContainer>
+      )}
     </>
   );
 };


### PR DESCRIPTION
close #160 

## ✅ 작업 내용
- 홈, 회원 정보, 회원 정보 수정 페이지에서 SEO 적용 안 되는 문제 수정 (아래는 로컬 환경에서 페이지 별로 적용된 사진입니다)
  - 홈페이지
      ![image](https://user-images.githubusercontent.com/96400112/211588215-0cce60ca-cfae-4fcb-a53a-5edc722f6a36.png)
  - 회원 정보 페이지
      ![image](https://user-images.githubusercontent.com/96400112/211588579-ab323e04-5b43-4f73-9a4d-331b6cdf63d7.png)
  - 회원 정보 수정 페이지
      ![image](https://user-images.githubusercontent.com/96400112/211588693-160d7489-7ad3-4330-af3e-c17709144aa2.png)


## ✍ 궁금한 점
- `null`로 반환하는 조건문이 있는 페이지에서 SEO가 적용 안 되던 거여서 수정은 했는데..코드가 조금 찜찜해졌는데 더 나은 방법이 있을까요?
- [og 카드 보는 사이트](https://www.opengraph.xyz/url/https%3A%2F%2Fdevwiki.co.kr%2Fquestion%2F44%3FmainCategory%3Dfe%26subCategory%3Dreact)로 한 번 보고 수정하고 싶은 점이 있다면 알려주세요.